### PR TITLE
Fixed build, release and folder structure in the continuous integration.

### DIFF
--- a/.github/workflows/betube32.yml
+++ b/.github/workflows/betube32.yml
@@ -39,20 +39,17 @@ jobs:
           cp -R locales dist/VeTube/
           cp -R sounds dist/VeTube/
           cp -R espeak-phonemizer-windows/espeak_phonemizer dist/VeTube/
-
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: VeTube-x86
           path: dist/VeTube
           if-no-files-found: error
-
       - name: zip packaging
         run: |
           cd dist/VeTube
           7z a ../../VeTube-x86.zip .
           cd ../../
-
-      - name: vetube_release:
+      - name: vetube_release
         uses: softprops/action-gh-release@v1
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:

--- a/.github/workflows/betube32.yml
+++ b/.github/workflows/betube32.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create zip
         run: |
           cd dist/VeTube
-          7z a ../VeTube-x86.zip ./
+          7z a ../../VeTube-x86.zip .
           cd ..
 
       - name: Upload zip

--- a/.github/workflows/betube32.yml
+++ b/.github/workflows/betube32.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Create zip
         run: |
-          cd dist
-          7z a ../VeTube-x86.zip VeTube/
+          cd dist/VeTube
+          7z a ../VeTube-x86.zip ./
           cd ..
 
       - name: Upload zip

--- a/.github/workflows/betube32.yml
+++ b/.github/workflows/betube32.yml
@@ -40,30 +40,21 @@ jobs:
           cp -R sounds dist/VeTube/
           cp -R espeak-phonemizer-windows/espeak_phonemizer dist/VeTube/
 
-      - name: Create zip
-        run: |
-          cd dist/VeTube
-          7z a ../../VeTube-x86.zip .
-          cd ..
-
-      - name: Upload zip
         uses: actions/upload-artifact@v3
         with:
           name: VeTube-x86
-          path: dist
+          path: dist/VeTube
           if-no-files-found: error
 
-  vetube_release:
-    runs-on: windows-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    needs: ["build"]
-    steps:
-    - uses: actions/checkout@v3
-    - name: download
-      uses: actions/download-artifact@v3
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: VeTube-x86.zip
-        fail_on_unmatched_files: true
-        prerelease: ${{ contains(github.ref, '-') }}
+      - name: zip packaging
+        run: |
+          cd dist/VeTube
+          7z a ../../VeTube-x86.zip .
+          cd ../../
+
+      - name: vetube_release:
+        uses: softprops/action-gh-release@v1
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          files: VeTube-x86.zip
+          prerelease: ${{ contains(github.ref, '-') }}

--- a/.github/workflows/betube64.yml
+++ b/.github/workflows/betube64.yml
@@ -40,30 +40,21 @@ jobs:
           cp -R sounds dist/VeTube/
           cp -R espeak-phonemizer-windows/espeak_phonemizer dist/VeTube/
 
-      - name: Create zip
-        run: |
-          cd dist/VeTube
-          7z a ../../VeTube-x64.zip .
-          cd ..
-
-      - name: Upload zip
         uses: actions/upload-artifact@v3
         with:
           name: VeTube-x64
-          path: dist
+          path: dist/VeTube
           if-no-files-found: error
 
-  vetube_release:
-    runs-on: windows-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    needs: ["build"]
-    steps:
-    - uses: actions/checkout@v3
-    - name: download
-      uses: actions/download-artifact@v3
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: VeTube-x64.zip
-        fail_on_unmatched_files: true
-        prerelease: ${{ contains(github.ref, '-') }}
+      - name: zip packaging
+        run: |
+          cd dist/VeTube
+          7z a ../../VeTube-x64.zip .
+          cd ../../
+
+      - name: vetube_release:
+        uses: softprops/action-gh-release@v1
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          files: VeTube-x64.zip
+          prerelease: ${{ contains(github.ref, '-') }}

--- a/.github/workflows/betube64.yml
+++ b/.github/workflows/betube64.yml
@@ -49,8 +49,7 @@ jobs:
           cd dist/VeTube
           7z a ../../VeTube-x64.zip .
           cd ../../
-
-      - name: vetube_release:
+      - name: vetube_release
         uses: softprops/action-gh-release@v1
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:

--- a/.github/workflows/betube64.yml
+++ b/.github/workflows/betube64.yml
@@ -40,11 +40,11 @@ jobs:
           cp -R sounds dist/VeTube/
           cp -R espeak-phonemizer-windows/espeak_phonemizer dist/VeTube/
 
-        uses: actions/upload-artifact@v3
-        with:
-          name: VeTube-x64
-          path: dist/VeTube
-          if-no-files-found: error
+      uses: actions/upload-artifact@v3
+      with:
+        name: VeTube-x64
+        path: dist/VeTube
+        if-no-files-found: error
 
       - name: zip packaging
         run: |

--- a/.github/workflows/betube64.yml
+++ b/.github/workflows/betube64.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create zip
         run: |
           cd dist/VeTube
-          7z a ../VeTube-x64.zip ./
+          7z a ../../VeTube-x64.zip .
           cd ..
 
       - name: Upload zip

--- a/.github/workflows/betube64.yml
+++ b/.github/workflows/betube64.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Create zip
         run: |
-          cd dist
-          7z a ../VeTube-x64.zip VeTube/
+          cd dist/VeTube
+          7z a ../VeTube-x64.zip ./
           cd ..
 
       - name: Upload zip

--- a/.github/workflows/betube64.yml
+++ b/.github/workflows/betube64.yml
@@ -39,7 +39,7 @@ jobs:
           cp -R locales dist/VeTube/
           cp -R sounds dist/VeTube/
           cp -R espeak-phonemizer-windows/espeak_phonemizer dist/VeTube/
-      uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: VeTube-x64
           path: dist/VeTube

--- a/.github/workflows/betube64.yml
+++ b/.github/workflows/betube64.yml
@@ -39,13 +39,11 @@ jobs:
           cp -R locales dist/VeTube/
           cp -R sounds dist/VeTube/
           cp -R espeak-phonemizer-windows/espeak_phonemizer dist/VeTube/
-
       uses: actions/upload-artifact@v3
-      with:
-        name: VeTube-x64
-        path: dist/VeTube
-        if-no-files-found: error
-
+        with:
+          name: VeTube-x64
+          path: dist/VeTube
+          if-no-files-found: error
       - name: zip packaging
         run: |
           cd dist/VeTube


### PR DESCRIPTION
* When you create a new release, the assets should be appeared in a few minutes after creating it.
* Now the zip doesn't include the "vetube" folder. You have to be carefully, and extract in a folder.