### PR TITLE
Corregir la identificación de plataforma cuando la interfaz no está en español

### DIFF
--- a/controller/main_controller.py
+++ b/controller/main_controller.py
@@ -1,6 +1,6 @@
 import wx
 from globals.data_store import favorite, mensajes_destacados, favs, msjs,config
-from ui.main_window import MyFrame
+from ui.main_window import MyFrame, PLATAFORMAS
 from os import remove
 from utils import languageHandler,canonical_scraper,funciones
 from controller.menus.main_menu_controller import MainMenuController
@@ -277,7 +277,11 @@ class MainController:
         
         self.frame.text_ctrl_1.SetValue(url)
         plataforma_ids = self.frame.plataforma.GetSelection()
-        plataforma = self.frame.plataforma.GetString(plataforma_ids)
+        # Identificador interno, no la etiqueta traducida del wx.Choice: con la
+        # interfaz en otro idioma la etiqueta no coincide con las comparaciones
+        # del código (p. ej. == 'La sala de juegos') y la plataforma se trata
+        # como genérica.
+        plataforma = PLATAFORMAS[plataforma_ids]
         
         # Create ChatController first
         chat_controller = ChatController(self, self.frame, plataforma=plataforma, chat_dialog=self.chat_dialog)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,6 +1,10 @@
 from utils.menu_accesible import Accesible
 import wx
 
+# Identificadores internos de las plataformas, en el mismo orden que el wx.Choice.
+# NO traducir ni reordenar: el código los compara tal cual (p. ej. == 'La sala de juegos').
+PLATAFORMAS = ["detectar", "YouTube", "Twich", "TikTok", "La sala de juegos", "Kick"]
+
 class MyFrame(wx.Frame):
     def __init__(self, *args, **kwds):
         kwds["style"] = kwds.get("style", 0) | wx.DEFAULT_FRAME_STYLE


### PR DESCRIPTION
## Problema

VeTube identifica la plataforma seleccionada leyendo la **etiqueta visible** del `wx.Choice` (`GetString(...)`) y usándola como identificador interno. Esa etiqueta está traducida por gettext, pero el código la compara con los nombres en español escritos en duro (`ui/chat_ui.py`, `controller/chat_controller.py`, `controller/menus/chat_menu_controller.py`).

Con la interfaz en cualquier idioma distinto del español esas comparaciones fallan. Lo verifiqué contra los catálogos `.mo` reales de los 6 idiomas: **14 de las 24 comparaciones de plataforma quedan rotas**:

| Comparación | Idiomas donde falla |
|---|---|
| `== 'La sala de juegos'` | los 6 (fr «Le Salon», en/cs/pl/id «QuentinC Playroom», pt «Sala de Jogos») |
| `== 'Twich'` | los 6 (todas las traducciones lo corrigen a «Twitch») |
| `== 'Kick'` | checo («Vykopnout uživatele»), portugués («kick») |
| `== 'TikTok'` | ninguno |

Efectos visibles (por ejemplo con la interfaz en francés):

- **La sala de juegos** recibe la interfaz genérica de 6 categorías (General, Eventos, Miembros, Moderadores, Donaciones, Verificados) en vez de sus 2 páginas («conversaciones» y «mensajes privados»). Para un usuario de lector de pantalla eso significa recorrer varias páginas vacías sin motivo, y los mensajes privados aparecen en una página mal etiquetada («Miembros»). Además su menú de opciones muestra «Copiar enlace», «Reproducir en el navegador» y «Favoritos», que no aplican a esta plataforma.
- **Twitch**: al agregar a favoritos, el título no se genera con `extractUser(url)` y se usa la etiqueta estática del diálogo.
- **Kick** en checo/portugués: copiar enlace y abrir en el navegador producen una URL sin el prefijo `https://www.kick.com/`.

## Solución

Identificar la plataforma por el **índice** de la selección mediante una lista interna no traducida (`PLATAFORMAS` en `ui/main_window.py`), dejando la etiqueta traducida solo para mostrar en la interfaz. Así todas las comparaciones existentes del código siguen funcionando tal cual en cualquier idioma, sin tocar ningún otro archivo (el identificador interno nunca se muestra al usuario).

Nota para el futuro: al añadir una plataforma nueva hay que añadirla en el mismo orden en el `wx.Choice` y en `PLATAFORMAS`.

## Pruebas

- Script de verificación contra los `.mo` compilados de los 6 idiomas: 14/24 comparaciones rotas antes del cambio, **0/24 después**.
- Probado en vivo desde el código fuente con la interfaz en francés y el cliente de La sala de juegos abierto (verificado con NVDA): la ventana de chat vuelve a tener sus 2 páginas, los mensajes llegan a «conversaciones», el menú de opciones ya no muestra las entradas que no aplican, y YouTube/Twitch siguen comportándose igual que antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)