### PR TITLE
Corregir la detección de mensajes privados en la sala de juegos

### DIFF
--- a/helpers/playroom_helper.py
+++ b/helpers/playroom_helper.py
@@ -1,3 +1,4 @@
+import re
 import uiautomation
 import win32gui
 import win32process
@@ -86,14 +87,17 @@ class PlayroomHelper:
                 if not line == '':
 
                     # to find private messages, we take our username which we found in the title bar. In order to avoid using language specific strings from playroom we will use the username and use it as a marker for privates.
-                    if self.username + ':' in line:
-                        processed_message = line[(line.find(self.username + ':') + len(self.username + ':')):]
+                    # The title bar can show the username in a different case than chat lines (e.g. title '[enzow]' but 'Mae18 dit à Enzow: coucou' in the chat), so the match must be case-insensitive.
+                    # A match at the very start of the line is one of our own lines (never an incoming private, the sender comes first), so it stays public.
+                    private_marker = re.search(re.escape(self.username) + ':', line, re.IGNORECASE)
+                    if private_marker is not None and private_marker.start() > 0:
+                        processed_message = line[private_marker.end():].strip()
                         # Find the first word and use it as author name (playroom disallows using spaces in usernames)
                         author = line.split(' ')[0]
                         new_messages.append({'type': 'private', 'message': processed_message, 'author': author})
                     elif ':' in line:
                         # If there is a colon in the message, it means it's public. There are very few other lines with colons (couldn't find any).
-                        processed_message = line[(line.find(':') + len(':')):]
+                        processed_message = line[(line.find(':') + len(':')):].strip()
                         # Find the first word and use it as author name (playroom disallows using spaces in usernames)
                         author = line.split(' ')[0]
                         new_messages.append({'type': 'public', 'message': processed_message, 'author': author})


### PR DESCRIPTION
## Problema

Los mensajes privados recibidos en la sala de juegos (Playroom) aparecían en la página de conversaciones en lugar de la página de mensajes privados.

## Causa

La barra de título del cliente puede mostrar el nombre de usuario con distinta capitalización que las líneas del chat. Por ejemplo, el título muestra `Le Salon [enzow]` (minúsculas) pero la línea del historial es `Mae18 dit à Enzow: coucou` (mayúscula inicial). La comparación en `helpers/playroom_helper.py` era sensible a mayúsculas (`self.username + ':' in line`), así que el marcador nunca coincidía y el privado recibido se clasificaba como público.

## Solución

- La búsqueda del marcador `<usuario>:` ahora ignora mayúsculas y minúsculas (`re.IGNORECASE`).
- Una coincidencia al inicio de la línea es un mensaje propio (un privado entrante siempre empieza por el nombre del remitente), así que se mantiene como público.
- Se elimina el espacio inicial sobrante del mensaje, que producía un doble espacio en pantalla (`Mae18:  coucou` → `Mae18: coucou`).

## Pruebas

- Probado en vivo desde el código fuente con NVDA y el cliente francés del Salón: un privado recibido ahora llega a la página de mensajes privados con su sonido; los mensajes públicos propios y de otros usuarios se quedan en conversaciones.
- La nueva lógica se validó además contra líneas reales capturadas de la ventana del cliente: privado recibido, público propio (`Enzow dit: salut`), público de otro usuario, privado enviado, variantes de mayúsculas y líneas sin dos puntos.

PR dirigida a la rama `canary` siguiendo el nuevo flujo de trabajo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)