### PR TITLE
Declarar pywin32 como dependencia directa en requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ git+https://github.com/KaitoCross/pytchat
 yt-dlp[default,curl-cffi]
 python-vlc
 wxPython
+pywin32


### PR DESCRIPTION
## Qué hace

Añade `pywin32` a `requirements.txt` (una sola línea).

## Por qué

VeTube importa pywin32 directamente en su propio código:

- `helpers/playroom_helper.py` (líneas 2-3): `import win32gui` / `import win32process`, para detectar la ventana de la sala de juegos. Este módulo se importa al arrancar la aplicación (`controller/main_controller.py` → `servicios/sala.py` → `helpers/playroom_helper.py`), así que **sin pywin32 VeTube no arranca**.
- `update/update.py` (línea 120): `import win32api`, para lanzar `bootstrap.exe` al aplicar una actualización.

Sin embargo, `pywin32` no está declarado en `requirements.txt`. Hoy se instala de rebote: `sound_lib` depende de `libloader` y `platform_utils`, y esas dos librerías dependen de `pywin32`. Es decir, funciona por casualidad — si en el futuro esas librerías cambiaran sus dependencias, `pip install -r requirements.txt` dejaría de instalar pywin32, y tanto las instalaciones desde el código fuente como el build de CI quedarían rotos silenciosamente.

Declararlo explícitamente cuesta una línea y elimina ese riesgo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)