### PR TITLE
Fix Favoritos chat tab bound to the wrong category checkbox

### DIFF
--- a/ui/chat_ui.py
+++ b/ui/chat_ui.py
@@ -31,7 +31,7 @@ class ChatPanel(wx.Panel):
             if data_store.config['categorias'][4]: self.list_box_moderadores, self.page_index_moderadores = self.create_page_with_listbox(self.treebook, _(u"Moderadores"))
             if data_store.config['categorias'][3]: self.list_box_donaciones, self.page_index_donaciones = self.create_page_with_listbox(self.treebook, _(u"Donaciones"))
             if data_store.config['categorias'][5]: self.list_box_verificados, self.page_index_verificados = self.create_page_with_listbox(self.treebook, _(u"Verificados"))
-        if data_store.config['categorias'][5]: self.list_box_favoritos, self.page_index_favoritos = self.create_page_with_listbox(self.treebook, _(u"Favoritos"))
+        if data_store.config['categorias'][6]: self.list_box_favoritos, self.page_index_favoritos = self.create_page_with_listbox(self.treebook, _(u"Favoritos"))
 
         self.treebook.SetFocus()
         main_sizer.Add(self.treebook, 1, wx.EXPAND | wx.ALL, 5)


### PR DESCRIPTION
## Problema

En `ChatPanel` (`ui/chat_ui.py`, línea 34), la pestaña **Favoritos** se creaba leyendo `categorias[5]`, que corresponde a la casilla **«Usuarios Verificados»** de la configuración. Todas las demás referencias usan `categorias[6]` (la casilla «Favoritos» real): el enlace del menú contextual en `ChatController._bind_events` (`controller/chat_controller.py`, línea 60) y el orden de `mensajes_categorias` (`globals/mensajes.py`).

Consecuencias para el usuario:
- Marcar solo «Favoritos» → la pestaña **no** se crea al abrir un chat.
- Marcar «Usuarios Verificados» sin «Favoritos» → aparece una pestaña Favoritos «fantasma», sin menú contextual ni lectura con espacio (porque el bind sí comprueba `[6]`).

## Corrección

Una línea: la creación de la pestaña ahora lee `categorias[6]`, igual que el resto del código. Afecta a todas las plataformas (la línea es común a TikTok, la sala y las genéricas).

## Verificación

- Banco de pruebas automatizado que instancia el `ChatPanel` real con distintas combinaciones de casillas: 9/9 correctas con el fix; con el código anterior fallan exactamente los 5 casos que describen el bug.
- Probado en vivo con NVDA: al marcar «Favoritos» (y desmarcar «Usuarios Verificados»), la pestaña Favoritos aparece correctamente al abrir un chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)