### PR TITLE
Fix TikTok chest events never being announced

### DIFF
--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -153,11 +153,13 @@ class ServicioTiktok:
 
     async def on_chest(self,event: EnvelopeEvent):
         if data_store.config['eventos'][9] and hasattr(self.chat_controller.ui, 'list_box_eventos'):
-            wx.CallAfter(self.chat_controller.agregar_mensaje_evento, event.user.nickname + _(" ha enviado un cofre!"), "chest")
+            # EnvelopeEvent no tiene campo 'user': el remitente viene en envelope_info
+            mensajito = event.envelope_info.send_user_name + _(" ha enviado un cofre!")
+            wx.CallAfter(self.chat_controller.agregar_mensaje_evento, mensajito, "chest")
             if data_store.config['sonidos'] and data_store.config['listasonidos'][12]:
                 wx.CallAfter(player.play, rutasonidos[12])
             if data_store.config['reader'] and data_store.config['unread'][9]:
-                wx.CallAfter(reader.leer_mensaje, event.user.nickname + _(" ha enviado un cofre!"))
+                wx.CallAfter(reader.leer_mensaje, mensajito)
 
     async def on_follow(self,event: FollowEvent):
         if data_store.config['eventos'][7] and hasattr(self.chat_controller.ui, 'list_box_eventos'):


### PR DESCRIPTION
## Problema

En `servicios/tiktok.py`, `on_chest` leía `event.user.nickname`, pero el evento `EnvelopeEvent` de TikTokLive (verificado contra la 6.6.5 instalada; en el protocolo es `WebcastEnvelopeMessage`) **no tiene campo `user`** — solo `base_message`, `envelope_info` y `display`.

Resultado: `AttributeError` en **cada cofre del tesoro**, tragado por el manejo de errores del bucle de eventos. Para el usuario la función simplemente no existe: el mensaje nunca aparece en «Eventos», el sonido del cofre (`listasonidos[12]`) nunca suena y el lector nunca lo anuncia — a pesar de que la configuración ofrece casillas y sonido dedicados para los cofres.

## Corrección

El nombre del remitente viene en `event.envelope_info.send_user_name` (campo real de `MessageRedEnvelopInfo`). Se construye el mensaje una sola vez, igual que hace `on_gift`. El msgid `" ha enviado un cofre!"` no cambia, así que **ninguna traducción necesita retocarse**.

## Verificación

Banco de pruebas que construye un `EnvelopeEvent` real (betterproto) y lo pasa por el `on_chest` real del servicio:
- Código anterior: excepción en cada cofre, ninguna anuncia (7 casos fallan).
- Con el fix: 10/10 — mensaje en «Eventos» con el nombre del remitente, sonido correcto, lectura por voz, y las combinaciones de configuración (`eventos[9]`, `reader`/`unread[9]`) se respetan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)