### PR TITLE
Fix contradictory announcements and dead retry loop when a TikTok live ends

### DIFF
--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -119,7 +119,10 @@ class ServicioTiktok:
         wx.CallAfter(reader.leer_sapi, _("El directo ha finalizado. Se buscará de nuevo en un minuto."))
 
     async def on_disconnect(self, event: DisconnectEvent):
-        if self.is_running:
+        # TikTokLive emite DisconnectEvent en cada cierre del websocket, incluido el fin
+        # normal del directo: en ese caso finalizado() ya anunció que se buscará de nuevo,
+        # así que dejamos que el bucle de _run_client_async siga sondeando cada minuto.
+        if self.is_running and self.last_live_status is not False:
             self.is_running = False
             wx.CallAfter(reader.leer_sapi, _("Se ha perdido la conexión. El servicio se ha detenido."))
 


### PR DESCRIPTION
## Problema

Cuando un directo de TikTok termina, TikTokLive emite `LiveEndEvent` y después **siempre** emite `DisconnectEvent` al cerrarse el websocket (lo hace al final de su bucle interno, sea cual sea la causa de la desconexión).

En `servicios/tiktok.py` eso producía dos anuncios contradictorios seguidos:

1. `finalizado()`: «El directo ha finalizado. **Se buscará de nuevo en un minuto.**»
2. `on_disconnect()`: «Se ha perdido la conexión. **El servicio se ha detenido.**»

Y el segundo era el verdadero: `on_disconnect` ponía `is_running = False`, así que el bucle de `_run_client_async` (que está diseñado justo para sondear `is_live()` cada 60 segundos) salía y la búsqueda prometida no ocurría nunca. Para volver a leer el chat cuando el streamer reabría el directo había que cerrar y reabrir la sesión a mano. Para un usuario ciego que depende del lector, dos anuncios contradictorios son especialmente desorientadores.

## Corrección

`on_disconnect` ahora ignora la desconexión **esperada** que sigue al fin del directo (`last_live_status` ya es `False`, puesto por `finalizado()`): el bucle sigue sondeando cada minuto y se reconecta solo cuando el usuario vuelve a estar en vivo. Una pérdida de conexión real **en pleno directo** (`last_live_status` aún `True`) conserva el comportamiento actual: detener y anunciar.

Ningún msgid cambia — no hay que retocar traducciones.

## Verificación

Banco de pruebas que ejecuta los manejadores reales (`finalizado`, `on_disconnect`, `_run_client_async`) — 13/13 con el fix, incluido el escenario completo: fin del directo → un solo anuncio → espera de 60 s (simulada) → el streamer vuelve → «El usuario está en vivo. Conectando...» → reconexión automática.

Con el código anterior fallan exactamente los dos síntomas (servicio detenido + anuncio contradictorio), y los casos «pérdida de conexión real» y «cierre por el usuario» pasan antes y después — es decir, ningún otro comportamiento cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)