### PR TITLE
Detener de verdad el bucle asyncio de TikTok cuando el servicio termina (hilo zombi)

### DIFF
--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -29,20 +29,31 @@ class ServicioTiktok:
         thread.start()
 
     def _start_async_loop(self):
+        # al terminar la corutina principal (desconexión real incluida) hay que parar
+        # el bucle: si no, run_forever sigue girando vacío y el hilo queda zombi
+        parar_bucle = lambda _tarea: self.loop.stop()
+        tarea_principal = None
         try:
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
-            self.loop.create_task(self._initialize_and_run_client())
+            tarea_principal = self.loop.create_task(self._initialize_and_run_client())
+            tarea_principal.add_done_callback(parar_bucle)
             self.loop.run_forever()
         except Exception as e:
             print(f"Error fatal en el hilo de conexión: {e}")
             traceback.print_exc()
         finally:
-            if self.loop.is_running():
-                pending = asyncio.all_tasks(loop=self.loop)
-                for task in pending:
-                    task.cancel()
+            if tarea_principal is not None:
+                tarea_principal.remove_done_callback(parar_bucle)
+            pending = asyncio.all_tasks(loop=self.loop)
+            for task in pending:
+                task.cancel()
+            try:
+                if pending:
+                    self.loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
                 self.loop.run_until_complete(self.loop.shutdown_asyncgens())
+            except RuntimeError:
+                pass  # un stop() rezagado de detener() puede vaciar el bucle antes de tiempo
             self.loop.close()
 
     async def _initialize_and_run_client(self):


### PR DESCRIPTION
## Problema

Dos defectos en `_start_async_loop` (servicios/tiktok.py), detectados durante la revisión del chat de TikTok:

1. **Hilo zombi tras una pérdida real de conexión.** `on_disconnect` pone `is_running = False` y anuncia «Se ha perdido la conexión. El servicio se ha detenido.», la corutina principal termina… pero nadie llamaba a `loop.stop()`. `run_forever()` seguía girando vacío **para siempre**: un hilo + un bucle asyncio zombis por cada directo terminado, acumulándose durante la sesión.
2. **La limpieza del `finally` era código muerto.** Después de que `run_forever()` retorna, `self.loop.is_running()` es siempre `False`, así que la condición nunca se cumplía: las tareas pendientes no se cancelaban antes de `close()` y asyncio avisaba `Task was destroyed but it is pending!` (visible en stderr al cerrar un chat de TikTok).

## Solución

Todo en `_start_async_loop` (sin solaparse con #63, que toca otras funciones del mismo archivo — se pueden fusionar en cualquier orden):

- Un `done_callback` en la tarea principal llama a `loop.stop()` cuando la corutina termina por cualquier camino (desconexión real incluida) → `run_forever()` retorna y el hilo muere limpiamente.
- El `finally` ahora cancela de verdad las tareas pendientes y deja que las cancelaciones se procesen (`gather` con `return_exceptions=True`) antes de `shutdown_asyncgens()`/`close()`. El callback se retira antes de cancelar, para que el `stop()` de la propia tarea principal cancelada no aborte la limpieza; y un `RuntimeError` por un `stop()` rezagado de `detener()` ya no puede saltarse el `close()`.

**Comportamiento conservado** (verificado en el banco de pruebas):

- `detener()` (arresto del usuario) funciona exactamente igual, sin anuncio de pérdida.
- El bucle de re-sondeo de 60 s tras el fin de un directo (#60) sigue vivo: el bucle solo se para cuando la corutina principal termina de verdad.

## Pruebas

Banco de pruebas automatizado con un cliente TikTokLive simulado (sin red), 16 comprobaciones — 3 fallos con el código anterior:

- **Pérdida real de conexión** → mensaje anunciado, `is_running=False` y **el bucle se cierra en <2 s** (antes: quedaba abierto para siempre = el zombi).
- **Arresto del usuario** vía `detener()` → bucle cerrado, sin anuncio de pérdida.
- **Usuario no está en vivo** → el re-sondeo sobrevive y `detener()` durante la espera cierra el bucle sin excepción.
- **Cero avisos `Task was destroyed but it is pending!`** (capturados vía el logger de asyncio; antes aparecían al parar el servicio).

Este defecto no es observable con un lector de pantalla (hilos invisibles en segundo plano), así que la validación es por simulación, como en #59; el banco simula el ciclo de vida completo del servicio (conexión, pérdida, arresto del usuario, re-sondeo) con el código real de `ServicioTiktok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
