### PR TITLE
Seguimiento del PR #65: correcciones de la revision de codigo

### DIFF
--- a/TTS/sonata_handler.py
+++ b/TTS/sonata_handler.py
@@ -85,7 +85,9 @@ class piperSpeak:
         self.espeak_dir = self.bin_dir
         
         self.bass_stream = None
-        
+        # Generación de habla: silence() la incrementa para invalidar síntesis en curso o pendientes.
+        self._speak_generation = 0
+
         # Iniciar Job Object en Windows
         if sys.platform == "win32":
             self.job_handle = CreateJobObject(None, None)
@@ -278,9 +280,11 @@ class piperSpeak:
     def speak(self, text):
         if not text: return
         self.silence()
-        asyncio.run_coroutine_threadsafe(self._speak_task(text), self.loop)
+        asyncio.run_coroutine_threadsafe(self._speak_task(text, self._speak_generation), self.loop)
 
     def silence(self):
+        # Invalida cualquier síntesis en curso o pendiente y corta el audio actual.
+        self._speak_generation += 1
         if self.bass_stream is not None:
             try:
                 self.bass_stream.stop()
@@ -288,10 +292,12 @@ class piperSpeak:
             except: pass
             self.bass_stream = None
 
-    async def _speak_task(self, text):
+    async def _speak_task(self, text, gen):
         if not self.voice_id or not self.channel:
             return
-            
+        if gen != self._speak_generation:
+            return  # silenciado antes de empezar
+
         rate_val = int(self.length_scale * 40)
         if rate_val < 5: rate_val = 5
         if rate_val > 200: rate_val = 200
@@ -300,19 +306,24 @@ class piperSpeak:
             voice_id=self.voice_id,
             text=text,
             speech_args=sonata_grpc_pb2.SpeechArgs(
-                rate=rate_val, 
+                rate=rate_val,
                 volume=self.volume,
                 pitch=self.pitch
             )
         )
-        
+
         try:
-            self.bass_stream = stream.PushStream(freq=self.sample_rate, chans=1)
-            self.bass_stream.volume = self.volume / 100.0
+            local_stream = stream.PushStream(freq=self.sample_rate, chans=1)
+            local_stream.volume = self.volume / 100.0
             if self.device != -1:
-                try: self.bass_stream.set_device(self.device)
+                try: local_stream.set_device(self.device)
                 except: pass
-            self.bass_stream.play()
+            if gen != self._speak_generation:
+                try: local_stream.free()
+                except: pass
+                return
+            self.bass_stream = local_stream
+            local_stream.play()
 
             async with self.channel.request(
                 '/sonata_grpc.sonata_grpc/SynthesizeUtterance',
@@ -322,9 +333,11 @@ class piperSpeak:
             ) as s:
                 await s.send_message(utterance, end=True)
                 async for result in s:
-                    if result.wav_samples and self.bass_stream is not None:
-                        self.bass_stream.push(result.wav_samples)
-                        
+                    if gen != self._speak_generation:
+                        break  # silenciado: dejar de empujar audio
+                    if result.wav_samples:
+                        local_stream.push(result.wav_samples)
+
         except Exception as e:
             print(f"Error en síntesis Sonata: {e}")
 
@@ -353,14 +366,8 @@ class piperSpeak:
                 pass
             self.job_handle = None
 
-        if self.bass_stream is not None:
-            try:
-                self.bass_stream.stop()
-                self.bass_stream.free()
-            except:
-                pass
-            self.bass_stream = None
-            
+        self.silence()
+
         if self.loop and self.loop.is_running():
             try:
                 self.loop.call_soon_threadsafe(self.loop.stop)

--- a/VeTube.pot
+++ b/VeTube.pot
@@ -657,7 +657,7 @@ msgid "iniciar/cancelar la captura de otro en vivo"
 msgstr ""
 
 #: globals/mensajes.py:3
-msgid "Silencia la voz sapy"
+msgid "Silencia todas las voces"
 msgstr ""
 
 #: globals/mensajes.py:4

--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -104,8 +104,7 @@ class AjustesController:
     def cambiar_sintetizador(self, event):
         if self.play_timer.IsRunning():
             self.play_timer.Stop()
-        if config['sistemaTTS'] != "piper":
-            reader._lector.silence()
+        reader._lector.silence()
         self.dialog.boton_prueva.SetLabel(_("&Reproducir prueba."))
         self.reproduciendo_prueba = False
 
@@ -237,8 +236,7 @@ class AjustesController:
     def cambiarVoz(self, event):
         if self.play_timer.IsRunning():
             self.play_timer.Stop()
-        if config['sistemaTTS'] != "piper":
-            reader._lector.silence()
+        reader._lector.silence()
         self.dialog.boton_prueva.SetLabel(_("&Reproducir prueba."))
         self.reproduciendo_prueba = False
 
@@ -346,9 +344,8 @@ class AjustesController:
     def on_destroy(self, event):
         if hasattr(self, 'play_timer') and self.play_timer.IsRunning():
             self.play_timer.Stop()
-        if config['sistemaTTS'] != "piper":
-            try:
-                reader._lector.silence()
-            except Exception:
-                pass
+        try:
+            reader._lector.silence()
+        except Exception:
+            pass
         event.Skip()

--- a/controller/chat_controller.py
+++ b/controller/chat_controller.py
@@ -112,8 +112,10 @@ class ChatController:
     def on_listbox_keyup(self, event):
         event.Skip()
         if event.GetKeyCode() == 32:
-            reader.silence()
             list_box = event.GetEventObject()
+            if list_box.GetSelection() == wx.NOT_FOUND:
+                return
+            reader.silence()
             reader.leer_auto(list_box.GetString(list_box.GetSelection()))
 
     def agregar_mensaje_general(self, mensaje):

--- a/helpers/reader_handler.py
+++ b/helpers/reader_handler.py
@@ -141,7 +141,7 @@ class ReaderHandler:
         self._lector.speak(mensaje)
 
     def silence(self):
-        # Silencia la voz principal y la voz SAPI secundaria, incluyendo lo pendiente en cola.
+        # Silencia la voz principal y la voz SAPI secundaria.
         self._lector.silence()
         self._leer.silence()
 

--- a/utils/key_utilitys.py
+++ b/utils/key_utilitys.py
@@ -74,12 +74,11 @@ class KeyUtils:
                 final_keys[key] = action
                 actions_assigned.add(action)
 
-        # 3. Reescribir solo si ha habido cambios
+        # 3. Reescribir solo si ha habido cambios, conservando las demás secciones del archivo
         if final_keys != original_keys:
-            new_config = configparser.ConfigParser(interpolation=None)
-            new_config['atajos_chat'] = final_keys
+            user_config['atajos_chat'] = final_keys
             with open(config_path, 'w', encoding='utf-8') as configfile:
-                new_config.write(configfile)
+                user_config.write(configfile)
         
         self.teclas = final_keys
 


### PR DESCRIPTION
Seguimiento del PR #65: son las correcciones de la auto-revisión que mencioné en el comentario de ese PR — las empujé justo después de que lo fusionaras, así que no entraron en el merge. Es el mismo commit, tal cual, sobre el canary actual.

## Qué corrige

- **piperSpeak: carrera de hilos al silenciar.** Una síntesis ya programada podía crear un stream nuevo y hablar *después* de Ctrl+P (el atajo parecía muerto), o empujar su audio en el stream del mensaje siguiente. Ahora hay un contador de generación: `silence()` lo incrementa y `_speak_task` lo verifica antes de crear el stream y antes de cada push, usando un stream local. `close()` reutiliza `silence()` en vez de duplicar el bloque.
- **key_utilitys: la reescritura de keys.txt conservaba solo `[atajos_chat]`.** Cualquier otra sección editada a mano (p. ej. `[atajos_player]`, que `chat_dialog_controller` sí lee) se perdía — y la migración del PR #65 fuerza esa reescritura una vez en todas las instalaciones existentes. Probado en real: ahora las demás secciones sobreviven.
- **ajustes_controller: eliminadas las 3 guardas `sistemaTTS != "piper"`** alrededor de `_lector.silence()`, obsoletas ahora que piperSpeak tiene `silence()`. De paso corrige un bug real: al cambiar de sintetizador o de voz mientras Piper hablaba, la voz vieja seguía sonando sin forma de pararla.
- **chat_controller: espacio sobre una lista vacía o sin selección** ya no intenta leer un índice inválido (guarda `wx.NOT_FOUND`).
- **VeTube.pot actualizado** con el nuevo msgid «Silencia todas las voces» (en el PR #65 solo actualicé los .po, no la plantilla).

## Prueba extra del PR #65

Verificamos a oído el caso principal: encolé 5 mensajes largos en la voz SAPI, `silence()` a los 3 segundos → se oyó el principio del mensaje uno, silencio total, y nada más. `stop()` de Prism sí purga toda la cola pendiente, que era justo lo que necesitábamos para el diluvio de comentarios al conectarse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
