### PR TITLE
Quitar el refresco de espectadores en Twitch (yt-dlp no lo soporta)

### DIFF
--- a/servicios/twich.py
+++ b/servicios/twich.py
@@ -21,7 +21,6 @@ class ServicioTwich:
         self.media_controller = None
         self.translator = None
         self._detener = False
-        self._event_refresco = threading.Event()
 
     def iniciar_chat(self):
         self._detener = False
@@ -32,7 +31,6 @@ class ServicioTwich:
 
     def detener(self):
         self._detener = True
-        self._event_refresco.set()
         if self.media_controller:
             self.media_controller.release()
 
@@ -52,8 +50,6 @@ class ServicioTwich:
             self.chat=ChatDownloader().get_chat(self.url,message_groups=["messages", "bits","subscriptions","upgrades"])
             threading.Thread(target=self.prepare_player, args=(self.chat.status,), daemon=True).start()
             wx.CallAfter(self.chat_controller.chat_dialog.update_chat_page_title, self.chat_controller, self.chat.title)
-            if self.chat.status != 'past':
-                self.iniciar_refresco_espectadores()
             for message in self.chat:
                 if self._detener: break
                 if not message: continue
@@ -161,21 +157,3 @@ class ServicioTwich:
         except Exception as e:
             wx.CallAfter(self.chat_controller.notificar_error, str(e))
 
-    def iniciar_refresco_espectadores(self):
-        self._event_refresco.clear()
-        self._hilo_refresco = threading.Thread(target=self._refrescar_espectadores_loop, daemon=True)
-        self._hilo_refresco.start()
-
-    def _refrescar_espectadores_loop(self):
-        from utils.play_mp4 import extract_live_viewers
-        while not self._detener:
-            espectadores = extract_live_viewers(self.url)
-            if espectadores is None:
-                break
-            if not self._detener:
-                title = self.chat.title + _(" en vivo, actualmente ") + str(espectadores) + _(" viendo ahora")
-                wx.CallAfter(self.chat_controller.agregar_titulo, title)
-                wx.CallAfter(self.chat_controller.chat_dialog.update_chat_page_title, self.chat_controller, title)
-            # Esperar 10 segundos, saliendo al instante si _event_refresco se activa
-            if self._event_refresco.wait(timeout=10):
-                break


### PR DESCRIPTION
Como me pediste: fuera la llamada para Twitch.

El motivo, verificado en el código de yt-dlp: solo el extractor de YouTube expone `concurrent_view_count`; el de Twitch no lo tiene, así que `extract_live_viewers` devolvía siempre None en Twitch y el hilo moría al primer intento, tras una llamada inútil a yt-dlp (~2 segundos de red y CPU por cada chat de Twitch abierto).

Retiro la llamada y también las dos funciones del bucle y el `threading.Event` que quedaban huérfanos: `servicios/twich.py` vuelve exactamente a su estado anterior a "preparing to 3.9".

Lo demás queda intacto:
- YouTube: probado en un directo real (France 24), funciona perfecto.
- Kick: usa su propia API (`viewer_count`), no yt-dlp.
- TikTok: ya recibía los espectadores por su evento nativo `RoomUserSeqEvent`, sin bucle.

Verificación: py_compile en verde y mi banco de pruebas de crashes (29/29, incluye los servicios) sin fallos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)