### PR TITLE
Arreglar la conexion a Twitch por nombre de usuario (arroba de mas en la URL)

### DIFF
--- a/controller/main_controller.py
+++ b/controller/main_controller.py
@@ -239,10 +239,12 @@ class MainController:
         
         # Si no autodetecta, construye la URL basada en la plataforma seleccionada y el texto actual
         if not autodetectar:
+            # Quita el arroba si el usuario lo escribió con el nombre; el código ya lo añade donde hace falta
+            url = url.lstrip('@')
             if plataforma_ids == 1:
                 url = "https://www.youtube.com/@" + url + "/live"
             elif plataforma_ids == 2:
-                url = "https://www.twitch.tv/@" + url
+                url = "https://www.twitch.tv/" + url
             elif plataforma_ids == 3:
                 url = "https://www.tiktok.com/@" + url + "/live"
             elif plataforma_ids == 5: # Nuevo: Kick


### PR DESCRIPTION
Hola Cesar,

Encontre este fallo usando VeTube en un directo real: elegir **Twitch** en la lista de plataformas y escribir **solo el nombre de usuario** (por ejemplo `renaud_dekode`) falla siempre con "Unable to find user".

## Causa

En `controller/main_controller.py`, la URL se construye asi:

    url = "https://www.twitch.tv/@" + url

Pero Twitch **no usa arroba** en sus URLs de canal (el patron se copio de YouTube/TikTok, donde si es correcto). chat-downloader recibe `@usuario` como nombre de canal y no encuentra al usuario. Esta asi desde la 3.0; paso desapercibido porque pegar la URL completa (con `http`/`www`) entra por la autodeteccion y funciona.

## Cambios

- Se quita el `@` de la URL construida para Twitch.
- Ademas, si el usuario escribe el nombre con arroba (`@usuario`), ahora se quita antes de construir la URL en todas las plataformas (antes producia un doble `@@` en YouTube y TikTok).

## Prueba

Probado en un directo real de Twitch: con `@` fallaba siempre, sin `@` conecta y lee el chat bien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
