### PR TITLE
Corregir la ruta del bypass de Kick en los builds distribuidos

### DIFF
--- a/servicios/kick.py
+++ b/servicios/kick.py
@@ -31,7 +31,8 @@ class ServicioKick:
     def _run_bypass_and_wait(self):
         dir_current_script = os.path.dirname(os.path.abspath(__file__))
         arch = "64" if platform.architecture()[0][:2] == "64" else "32"
-        path_to_arch_dir = os.path.join(os.getcwd(), arch)
+        # Ruta relativa al código, no al cwd: en el build instalado la carpeta 64 vive dentro de _internal (igual que en players/vlc_helper.py)
+        path_to_arch_dir = os.path.abspath(os.path.join(dir_current_script, '..', arch))
         bypass_executable = os.path.join(path_to_arch_dir, f"bypass{arch}.exe")
 
         if not os.path.exists(bypass_executable):


### PR DESCRIPTION
## Problema

Kick no funciona en las versiones distribuidas (ni el zip portátil ni el instalador): la conexión falla siempre con el error de bypass no encontrado. Solo funciona al ejecutar VeTube desde el código fuente, y por eso nunca lo vimos en desarrollo.

## Causa

`servicios/kick.py` construía la ruta del bypass a partir del directorio de trabajo (`os.path.join(os.getcwd(), arch)`), pero el workflow copia la carpeta `64` dentro de `_internal` (`cp -R 64 dist/VeTube/_internal/`). En la versión compilada el archivo queda en `{app}\_internal\64\bypass64.exe`, mientras que el código lo buscaba en `{app}\64\bypass64.exe`, que no existe. Verificado en los workflows de la v3.7, v3.8 y v3.9: el bug está en todas las versiones publicadas.

## Solución (opción 1, como acordamos por WhatsApp)

La ruta se construye ahora a partir del propio módulo, reutilizando la variable `dir_current_script` que ya se calculaba en la línea anterior (y no se usaba):

```python
path_to_arch_dir = os.path.abspath(os.path.join(dir_current_script, '..', arch))
```

Es la misma técnica que ya usan `players/vlc_helper.py` (por eso el reproductor VLC sí funciona instalado) y `TTS/sonata_handler.py` (por eso Piper sí funciona instalado). Funciona en desarrollo, en la versión instalada, y también si alguien lanza VeTube desde otra carpeta de trabajo.

## Pruebas

Banco de pruebas que ejecuta el `_run_bypass_and_wait` real con un subprocess simulado (sin lanzar el exe):

- caso desarrollador (cwd = raíz del repo): funciona antes y después del cambio, sin regresión;
- lanzado desde otra carpeta (cwd = `C:\`): fallaba antes, funciona después;
- simulación del layout instalado (`{app}\_internal`, el mismo que producen el zip y el instalador): fallaba antes, funciona después;
- verificación de una instalación real de la 3.9: no hay carpeta `64` en la raíz y el bypass está en `_internal\64`, exactamente el estado que ahora el código resuelve bien.

No es posible probar contra un directo real de Kick desde un build compilado sin generar una release, pero la simulación reproduce fielmente el layout que produce el workflow (mismo criterio de validación por simulación que en los PR #59 y #64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
