### PR TITLE
Tres correcciones menores: donación invertida, sonido del dispositivo y token de Discord oculto

### DIFF
--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -212,7 +212,7 @@ class AjustesController:
         valor_str = self.dialog.lista_dispositivos.GetStringSelection()
         config['dispositivo'] = valor
         player.setdevice(config["dispositivo"])
-        player.play("sounds/cambiardispositivo.mp3")
+        player.play(f"sounds/{config['directorio']}/cambiardispositivo.mp3")
         if config['sistemaTTS'] == "piper":
             if lista_voces_piper and lista_voces_piper[0] != 'No hay voces instaladas':
                 # Reutilizamos los nombres que ya tiene el player formateados para Sonata

--- a/globals/resources.py
+++ b/globals/resources.py
@@ -20,8 +20,8 @@ nombres_sonidos = [
     "share.mp3",
     "chest.mp3"
 ]
-# msj.mp3 y orilla.mp3 no están en la lista: chat_controller los reproduce directamente
-sonidos_requeridos = nombres_sonidos + ["msj.mp3", "orilla.mp3"]
+# msj.mp3, orilla.mp3 y cambiardispositivo.mp3 no están en la lista: se reproducen directamente
+sonidos_requeridos = nombres_sonidos + ["msj.mp3", "orilla.mp3", "cambiardispositivo.mp3"]
 rutasonidos = []
 
 def listar_temas_sonidos():

--- a/ui/discord_token_dialog.py
+++ b/ui/discord_token_dialog.py
@@ -20,7 +20,7 @@ class DiscordTokenDialog(wx.Dialog):
         sizer.Add(intro, 0, wx.ALL, 10)
         label = wx.StaticText(self, wx.ID_ANY, _("&Token del bot:"))
         sizer.Add(label, 0, wx.LEFT | wx.RIGHT, 10)
-        self.token_ctrl = wx.TextCtrl(self, wx.ID_ANY, "")
+        self.token_ctrl = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_PASSWORD)
         sizer.Add(self.token_ctrl, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
         self.boton_guia = wx.Button(self, wx.ID_ANY, _("¿No sabes cómo crear el token? Abrir la &guía"))
         self.boton_guia.Bind(wx.EVT_BUTTON, self.abrir_guia)

--- a/update/update.py
+++ b/update/update.py
@@ -23,7 +23,7 @@ def perform_update(update_url, donations=True, password=None, progress_callback=
     download_path = os.path.join(base_path, 'update.zip')
     update_path = os.path.join(base_path, 'update')
     
-    if not donations: donation()
+    if donations: donation()
     
     with httpx.Client(follow_redirects=True, timeout=None) as client:
         downloaded = download_update(update_url, download_path, client=client, progress_callback=progress_callback)

--- a/update/update.py
+++ b/update/update.py
@@ -23,7 +23,8 @@ def perform_update(update_url, donations=True, password=None, progress_callback=
     download_path = os.path.join(base_path, 'update.zip')
     update_path = os.path.join(base_path, 'update')
     
-    if donations: donation()
+    # perform_update corre en un hilo aparte (updater.py); el diálogo va al hilo de la UI
+    if donations: wx.CallAfter(donation)
     
     with httpx.Client(follow_redirects=True, timeout=None) as client:
         downloaded = download_update(update_url, download_path, client=client, progress_callback=progress_callback)


### PR DESCRIPTION
## Problemas corregidos

1. **Diálogo de donación invertido en las actualizaciones.** `perform_update` mostraba el diálogo de donación a quienes **desactivaron** la casilla (`if not donations`) y no a quienes la tienen activada. Ahora coincide con el arranque (`run_main_window.py`, línea 24). Además, como `perform_update` corre en un hilo aparte (`updater.py`), el diálogo se difiere al hilo de la interfaz con `wx.CallAfter`, igual que los demás avisos de `updater.py`; así tampoco retrasa el inicio de la descarga.

2. **El sonido de confirmación al cambiar el dispositivo de audio nunca sonó.** Al pulsar «&Establecer» se reproducía `sounds/cambiardispositivo.mp3`, una ruta que no existe (el mp3 vive dentro de cada tema: `sounds/default/`, `sounds/soniditos/`). El `BassError` resultante además cortaba el resto del handler: no se aplicaba el cambio de dispositivo de Piper ni se oía la confirmación hablada. Ahora se usa el tema activo, como el resto de los sonidos, y `cambiardispositivo.mp3` se añade a `sonidos_requeridos` para que un tema incompleto no pase la validación del selector.

3. **El token del bot de Discord se mostraba en claro.** El campo del diálogo ahora se enmascara con `wx.TE_PASSWORD` (evita exponer el token compartiendo pantalla en un directo, por ejemplo). Pegar el token y validarlo funciona exactamente igual.

## Pruebas

- Banco de pruebas dedicado: **19/19 ✓** — `perform_update` con las etapas de red/zip/bootstrap simuladas (el diálogo se llama solo con `donations=True` y siempre vía `wx.CallAfter`; la actualización se completa en ambos casos); la ruta del sonido existe en los dos temas incluidos y ambos siguen pasando la validación endurecida; el campo del token lleva `TE_PASSWORD` y `get_token()` sigue leyendo y limpiando el valor.
- `py_compile` en los 4 archivos modificados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
