### PR TITLE
Restaurar el diálogo de donación intencional al actualizar y quitar la entrada Windows32

### DIFF
--- a/update/update.py
+++ b/update/update.py
@@ -23,8 +23,11 @@ def perform_update(update_url, donations=True, password=None, progress_callback=
     download_path = os.path.join(base_path, 'update.zip')
     update_path = os.path.join(base_path, 'update')
     
-    # perform_update corre en un hilo aparte (updater.py); el diálogo va al hilo de la UI
-    if donations: wx.CallAfter(donation)
+    # A PROPÓSITO invertido respecto al inicio (run_main_window.py): este diálogo es un
+    # recordatorio para quienes DESACTIVARON la casilla de donaciones, por si les nace
+    # contribuir; los que la tienen activa ya lo ven en cada inicio. NO "corregir".
+    # perform_update corre en un hilo aparte (updater.py); el diálogo va al hilo de la UI.
+    if not donations: wx.CallAfter(donation)
     
     with httpx.Client(follow_redirects=True, timeout=None) as client:
         downloaded = download_update(update_url, download_path, client=client, progress_callback=progress_callback)

--- a/updater.json
+++ b/updater.json
@@ -2,7 +2,6 @@
     "current_version": "3.9",
     "description": "varios errores corregidos, soporte a discord",
     "downloads": {
-        "Windows32": "https://github.com/metalalchemist/VeTube/releases/download/v3.7/VeTube-x86.zip",
         "Windows64": "https://github.com/metalalchemist/VeTube/releases/latest/download/VeTube-x64.zip"
     }
 }


### PR DESCRIPTION
Como hablamos por WhatsApp, dos ajustes de seguimiento antes del parche:

## 1. Diálogo de donación al actualizar: restaurado tal como lo tenías

En el PR #76 «corregimos» la condición del diálogo de donación en `perform_update()` creyendo que estaba invertida — pero como explicaste, era a propósito: el diálogo al actualizar es un recordatorio para quienes desactivaron la casilla, por si les nace contribuir (los que la tienen activa ya lo ven en cada inicio). Lo comprobé en el historial: la v3.7 ya hacía `if not donations: donation()`.

- Se restaura `if not donations:`.
- Se conserva el `wx.CallAfter` del PR #76: `perform_update` corre en un hilo aparte (updater.py) y mostrar un diálogo wx desde un hilo secundario no es seguro, además de que bloqueaba la descarga. Ahora que el diálogo sí va a mostrarse, importa más todavía.
- Dejé un comentario en el código explicando la intención, para que nadie lo vuelva a «corregir».

## 2. updater.json: fuera la entrada Windows32

Con tu «Sí habría que quitarlo»: la entrada apuntaba a la v3.7, así que un usuario de 32 bits veía «versión nueva», descargaba la 3.7 otra vez y quedaba en un bucle infinito.

Comprobado que es seguro para los clientes viejos: el código de la v3.7 ya tenía la guarda `arch_key not in available_update['downloads']`, así que responde «no update for this architecture» y termina limpio, sin error. Los de 32 bits simplemente dejarán de ver actualizaciones (ya no se compilan builds de 32 bits).

## Pruebas

- Banco de pruebas nuevo, 20/20: los tres casos del diálogo (casilla desactivada → sale una vez vía CallAfter; activada → no sale; valor por defecto → no sale), la actualización se descarga en todos los casos, updater.json válido y sin Windows32, y la guarda de arquitectura presente tanto en canary como en la v3.7 (verificado con `git show v3.7:update/update.py`).
- `py_compile` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)