### PR TITLE
Correcciones menores de robustez y accesibilidad

### DIFF
--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -55,7 +55,7 @@ class AjustesController:
         self.dialog.check_donaciones.Bind(wx.EVT_CHECKBOX, lambda event: self.checar(event, 'donations'))
         self.dialog.check_2.Bind(wx.EVT_CHECKBOX, self.mostrarSonidos)
         self.dialog.lista_temas.Bind(wx.EVT_CHOICE, self.cambiar_tema_sonidos)
-        self.dialog.reproducir.Bind(wx.EVT_BUTTON, lambda event: player.play(rutasonidos[self.dialog.soniditos.GetFocusedItem()]))
+        self.dialog.reproducir.Bind(wx.EVT_BUTTON, self.reproducir_sonido)
         self.dialog.seleccionar_TTS.Bind(wx.EVT_CHOICE, self.cambiar_sintetizador)
         self.dialog.establecer_dispositivo.Bind(wx.EVT_BUTTON, self.establecer_dispositivo)
         self.dialog.boton_prueva.Bind(wx.EVT_BUTTON, self.reproducirPrueva)
@@ -99,6 +99,11 @@ class AjustesController:
         recargar_rutasonidos()
         if config['sonidos']: player.play(rutasonidos[0])
 
+    def reproducir_sonido(self, event):
+        idx = self.dialog.soniditos.GetFocusedItem()
+        if 0 <= idx < len(rutasonidos):
+            player.play(rutasonidos[idx])
+
     def checar(self, event, key):
         config[key] = True if event.IsChecked() else False
 
@@ -118,7 +123,7 @@ class AjustesController:
         reader.set_tts(config['sistemaTTS'])
         self.dialog.choice_2.Clear()
         if config['sistemaTTS'] == "piper":
-            if lista_voces_piper and lista_voces_piper[0] != 'No hay voces instaladas':
+            if lista_voces_piper and lista_voces_piper[0] != _("No hay voces instaladas"):
                 voz_index = config.get('voz', 0)
                 if voz_index >= len(lista_voces_piper):
                     voz_index = 0
@@ -214,7 +219,7 @@ class AjustesController:
         player.setdevice(config["dispositivo"])
         player.play(f"sounds/{config['directorio']}/cambiardispositivo.mp3")
         if config['sistemaTTS'] == "piper":
-            if lista_voces_piper and lista_voces_piper[0] != 'No hay voces instaladas':
+            if lista_voces_piper and lista_voces_piper[0] != _("No hay voces instaladas"):
                 # Reutilizamos los nombres que ya tiene el player formateados para Sonata
                 nombres = player.devicenames
                 dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres)]
@@ -223,7 +228,7 @@ class AjustesController:
 
     def reproducirPrueva(self, event):
         if config['sistemaTTS'] == "piper":
-            if self.dialog.choice_2.GetStringSelection() != 'No hay voces instaladas':
+            if self.dialog.choice_2.GetStringSelection() != _("No hay voces instaladas"):
                 reader.leer_auto(_("Hola, soy la voz que te acompañará de ahora en adelante a leer los mensajes de tus canales favoritos."))
         else:
             if self.reproduciendo_prueba:
@@ -281,7 +286,7 @@ class AjustesController:
         reader._leer.set_rate(value)
         if config['sistemaTTS'] == "piper":
             voz_actual = lista_voces_piper[self.dialog.choice_2.GetSelection()]
-            if voz_actual != 'No hay voces instaladas':
+            if voz_actual != _("No hay voces instaladas"):
                 reader._lector.set_rate(app_utilitys.porcentaje_a_escala(value))
         else:
             reader._lector.set_rate(value)

--- a/controller/chat_controller.py
+++ b/controller/chat_controller.py
@@ -158,7 +158,9 @@ class ChatController:
         dialogo.Raise()
         if dialogo.ShowModal() == wx.ID_OK:
             criterio = dialogo.GetValue()
-            if not criterio: return
+            if not criterio:
+                dialogo.Destroy()
+                return
 
             resultados = []
             list_boxes = []

--- a/controller/main_controller.py
+++ b/controller/main_controller.py
@@ -125,6 +125,9 @@ class MainController:
                     lf.SetFocus()
             else:
                 sel = lf.GetSelection()
+                if sel == wx.NOT_FOUND:
+                    lf.SetFocus()
+                    return
                 lf.Delete(sel)
                 favorite.pop(sel)
                 funciones.escribirJsonLista('favoritos.json', favorite)

--- a/controller/piper_downloader_controller.py
+++ b/controller/piper_downloader_controller.py
@@ -6,7 +6,7 @@ import shutil
 from setup import network, player, reader
 from servicios.piper_manager import PiperManager
 from ui.piper_downloader import PiperDownloaderDialog
-from TTS.list_voices import piper_list_voices
+from TTS.list_voices import piper_list_voices, obtener_ruta_voz
 
 class PiperDownloaderController:
     def __init__(self, parent):
@@ -67,7 +67,7 @@ class PiperDownloaderController:
             return
         
         voz_nombre = self.voces_locales[selection]
-        ruta_modelo = os.path.join("voices", f"voice-{voz_nombre[:-5]}", voz_nombre)
+        ruta_modelo = obtener_ruta_voz(voz_nombre)
         
         self.view.set_status(_("Probando voz local: %s") % voz_nombre)
         
@@ -88,9 +88,8 @@ class PiperDownloaderController:
         if wx.MessageBox(_("¿Estás seguro de que deseas eliminar la voz %s? Esta acción no se puede deshacer.") % voz_nombre, 
                          _("Confirmar eliminación"), wx.YES_NO | wx.ICON_WARNING) == wx.ID_YES:
             
-            # La carpeta suele ser voice-<nombre_sin_onnx>
-            folder_name = f"voice-{voz_nombre[:-5]}"
-            path_to_remove = os.path.join("voices", folder_name)
+            # piper_list_voices() ya devuelve el nombre de la carpeta (voice-...)
+            path_to_remove = os.path.join("voices", voz_nombre)
             
             try:
                 if os.path.exists(path_to_remove):

--- a/players/sound_helper.py
+++ b/players/sound_helper.py
@@ -51,6 +51,9 @@ class SoundPlayer:
 		if self.sound.is_playing: self.sound.pause()
 		else: self.sound.play()
 
+	def is_playing(self):
+		return self.sound is not None and hasattr(self.sound, 'is_playing') and self.sound.is_playing
+
 	def atrasar(self, seconds):
 		if not self.sound: return
 		current_pos = self.sound.get_position()

--- a/ui/ajustes/general.py
+++ b/ui/ajustes/general.py
@@ -11,7 +11,10 @@ class PanelGeneral(wx.Panel):
 		label_language = wx.StaticText(self, wx.ID_ANY, _("Idioma de VeTube (Requiere reiniciar)"))
 		boxSizer_1.Add(label_language, 0, wx.ALL, 5)
 		self.choice_language = wx.Choice(self, wx.ID_ANY, choices=langs)
-		self.choice_language.SetSelection(codes.index(config['idioma']))
+		try:
+			self.choice_language.SetSelection(codes.index(config['idioma']))
+		except ValueError:
+			self.choice_language.SetSelection(0)
 		boxSizer_1.Add(self.choice_language, 0, wx.EXPAND | wx.ALL, 5)
 		self.check_donaciones = wx.CheckBox(self, wx.ID_ANY, _("Activar diálogo de donaciones al inicio de la app."))
 		self.check_donaciones.SetValue(config['donations'])

--- a/ui/chat_ui.py
+++ b/ui/chat_ui.py
@@ -47,13 +47,16 @@ class ChatPanel(wx.Panel):
 
     def create_page_with_listbox(self, parent, name, plataforma=None):
         page = wx.Panel(parent)
+        page.SetName(str(name))
         sizer = wx.BoxSizer(wx.VERTICAL)
         list_box = wx.ListBox(page, wx.ID_ANY)
+        list_box.SetName(str(name))
         sizer.Add(list_box, 1, wx.EXPAND | wx.ALL, 5)
         if plataforma == 'TikTok' and name == _(u"Eventos"):
             self.boton_filtrar = wx.Button(page, wx.ID_ANY, _(u"&Filtrar por"))
             self.boton_filtrar.SetAccessible(Accesible(self.boton_filtrar))
             sizer.Add(self.boton_filtrar, 0, wx.ALL | wx.ALIGN_RIGHT, 5)
         page.SetSizer(sizer)
-        page_index = parent.AddPage(page, str(name))
+        parent.AddPage(page, str(name))
+        page_index = parent.GetPageCount() - 1
         return list_box, page_index

--- a/utils/funciones.py
+++ b/utils/funciones.py
@@ -14,7 +14,9 @@ def escribirJsonLista(arch,lista=[]):
 	with open(arch, 'w+') as file: json.dump(lista, file)
 def leerJsonLista(arch):
 	if path.exists(arch):
-		with open (arch) as file: return json.load(file)
+		try:
+			with open (arch) as file: return json.load(file)
+		except (json.JSONDecodeError, ValueError, OSError): return []
 	else: return []
 def convertirLista(lista, val1, val2):
 	if len(lista)<=0: return []


### PR DESCRIPTION
## Qué es

Un lote de correcciones pequeñas, aisladas y **sin cambios de traducción**, sobre canary (posterior a 3.91). **No toca el actualizador.**

Probado bajo NVDA (todo funciona) + banco de pruebas automático **16/16** (con funciones reales: `leerJsonLista`, `piper_list_voices`/`obtener_ruta_voz`, `SoundPlayer.is_playing`, guarda de índice) y `py_compile` de los 8 archivos.

## Robustez / arranque
- **utils/funciones.py** — `leerJsonLista` protege `json.load` con try/except: un `favoritos.json` / `mensajes_destacados.json` corrupto (escritura interrumpida) ya no impide el arranque; devuelve `[]`.
- **ui/ajustes/general.py** — `SetSelection(codes.index(idioma))` protegido con `try/except ValueError`: un idioma guardado que ya no existe (locale retirado, o data.json editado) ya no impide abrir la ventana de Ajustes.

## Accesibilidad (NVDA)
- **ui/chat_ui.py** — `SetName` en la ListBox y la página de cada categoría (General, Miembros, Donaciones…), para que el lector anuncie el contexto de la lista.
- **ui/chat_ui.py** — `AddPage` devuelve un bool, no el índice real; se usa `GetPageCount()-1`, corrigiendo el foco a la pestaña de resultados tras una búsqueda.

## Funciones que estaban rotas
- **controller/piper_downloader_controller.py** — los botones **Probar** y **Eliminar** de voces locales usaban un doble prefijo `voice-{voz[:-5]}` (rutas inexistentes), ya que `piper_list_voices()` devuelve el nombre de carpeta `voice-…`. Ahora usan `obtener_ruta_voz(voz_nombre)` y `voices/<voz_nombre>`.
- **players/sound_helper.py** — faltaba `SoundPlayer.is_playing()`; pausar/alternar un medio `'mp4'` lanzaba `AttributeError`.
- **controller/ajustes_controller.py** — el centinela `"No hay voces instaladas"` se guarda **traducido** (resources.py), pero se comparaba con el literal en español, dejando la guarda inerte fuera del español. Ahora se compara con `_()`.

## UX / datos
- **controller/ajustes_controller.py** — el botón «reproducir» (sonidos) reproducía el último sonido cuando no había nada enfocado (`GetFocusedItem()==-1`); ahora con guarda de índice.
- **controller/main_controller.py** — borrar un favorito sin selección disparaba una aserción de wx y borraba el favorito equivocado (el último); guarda `wx.NOT_FOUND`.
- **controller/chat_controller.py** — el diálogo de búsqueda no se destruía si el criterio estaba vacío (fuga de ventana nativa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)