### PR TITLE
Añade sistema de logs central y captura de errores no controlados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 favoritos.json
 keys.txt
 .vscode
+logs/

--- a/run_main_window.py
+++ b/run_main_window.py
@@ -1,4 +1,8 @@
 #To resume this session: gemini --resume "44dd7d2c-5663-42a5-9e3b-ab471b033308"
+# Configuramos los logs lo antes posible, antes de cualquier otro import del programa,
+# para capturar también los errores que ocurran durante el arranque.
+from utils.logging_setup import configurar_logs
+configurar_logs()
 import asyncio,sys,wx,setup
 from globals.data_store import config
 from globals.resources import carpeta_voces,lista_voces_piper

--- a/update/update.py
+++ b/update/update.py
@@ -19,25 +19,32 @@ from setup import network
 logger = getLogger('update')
 
 def perform_update(update_url, donations=True, password=None, progress_callback=None, update_complete_callback=None):
-    base_path = tempfile.mkdtemp()
-    download_path = os.path.join(base_path, 'update.zip')
-    update_path = os.path.join(base_path, 'update')
-    
-    # A PROPÓSITO invertido respecto al inicio (run_main_window.py): este diálogo es un
-    # recordatorio para quienes DESACTIVARON la casilla de donaciones, por si les nace
-    # contribuir; los que la tienen activa ya lo ven en cada inicio. NO "corregir".
-    # perform_update corre en un hilo aparte (updater.py); el diálogo va al hilo de la UI.
-    if not donations: wx.CallAfter(donation)
-    
-    with httpx.Client(follow_redirects=True, timeout=None) as client:
-        downloaded = download_update(update_url, download_path, client=client, progress_callback=progress_callback)
-    
-    extracted = extract_update(downloaded, update_path, password=password)
-    bootstrap_path = move_bootstrap(extracted)
-    if callable(update_complete_callback):
-        update_complete_callback()
-    execute_bootstrap(bootstrap_path, extracted)
-    logger.info("Update prepared for installation.")
+    # perform_update corre en un hilo aparte (updater.py). Si algo falla (antivirus,
+    # firewall, conexión, permisos...), la excepción moriría en silencio y el usuario
+    # solo vería que "no pasa nada". La registramos para poder diagnosticar el caso.
+    try:
+        base_path = tempfile.mkdtemp()
+        download_path = os.path.join(base_path, 'update.zip')
+        update_path = os.path.join(base_path, 'update')
+        logger.info("Iniciando actualización desde %s", update_url)
+
+        # A PROPÓSITO invertido respecto al inicio (run_main_window.py): este diálogo es un
+        # recordatorio para quienes DESACTIVARON la casilla de donaciones, por si les nace
+        # contribuir; los que la tienen activa ya lo ven en cada inicio. NO "corregir".
+        # perform_update corre en un hilo aparte (updater.py); el diálogo va al hilo de la UI.
+        if not donations: wx.CallAfter(donation)
+
+        with httpx.Client(follow_redirects=True, timeout=None) as client:
+            downloaded = download_update(update_url, download_path, client=client, progress_callback=progress_callback)
+
+        extracted = extract_update(downloaded, update_path, password=password)
+        bootstrap_path = move_bootstrap(extracted)
+        if callable(update_complete_callback):
+            update_complete_callback()
+        execute_bootstrap(bootstrap_path, extracted)
+        logger.info("Update prepared for installation.")
+    except Exception:
+        logger.exception("Fallo al descargar o instalar la actualización")
 
 async def async_check_update(endpoint, current_version):
     try:

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Configuración central de logs de VeTube.
+
+Escribe un archivo rotativo en la carpeta ``logs`` junto al programa y captura
+las excepciones no controladas (hilo principal e hilos secundarios). Está pensado
+para no romper nunca el arranque: si algo falla al configurar los logs, la app
+sigue funcionando sin registro.
+"""
+import logging
+import logging.handlers
+import os
+import sys
+import threading
+
+# Bibliotecas de terceros que generan mucho ruido en DEBUG: las bajamos a WARNING
+# para que el archivo de log siga siendo legible y útil para diagnosticar.
+_LIBRERIAS_RUIDOSAS = (
+    "httpx", "httpcore", "urllib3", "asyncio", "PIL",
+    "comtypes", "websocket", "websockets", "TikTokLive",
+)
+
+_configurado = False
+_log = logging.getLogger("vetube")
+
+
+def carpeta_logs():
+    """Devuelve la ruta de la carpeta de logs (junto al ejecutable o al proyecto)."""
+    if getattr(sys, "frozen", False):
+        base = os.path.dirname(sys.executable)
+    else:
+        base = os.getcwd()
+    return os.path.join(base, "logs")
+
+
+def configurar_logs(nivel=logging.DEBUG):
+    """Configura el logger raíz una sola vez. Seguro de llamar varias veces."""
+    global _configurado
+    if _configurado:
+        return
+
+    formato = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    raiz = logging.getLogger()
+    raiz.setLevel(nivel)
+
+    # Archivo rotativo: máx. ~1 MB por archivo, 5 copias -> tope de ~6 MB.
+    try:
+        destino = carpeta_logs()
+        os.makedirs(destino, exist_ok=True)
+        manejador_archivo = logging.handlers.RotatingFileHandler(
+            os.path.join(destino, "vetube.log"),
+            maxBytes=1_000_000,
+            backupCount=5,
+            encoding="utf-8",
+        )
+        manejador_archivo.setFormatter(formato)
+        raiz.addHandler(manejador_archivo)
+    except OSError:
+        # Si no se puede crear la carpeta o el archivo (permisos, disco lleno...),
+        # no rompemos el arranque: seguimos sin log en archivo.
+        pass
+
+    # En desarrollo (no congelado) también mostramos por consola.
+    if not getattr(sys, "frozen", False):
+        manejador_consola = logging.StreamHandler()
+        manejador_consola.setFormatter(formato)
+        raiz.addHandler(manejador_consola)
+
+    for nombre in _LIBRERIAS_RUIDOSAS:
+        logging.getLogger(nombre).setLevel(logging.WARNING)
+
+    _instalar_captura_excepciones()
+
+    _configurado = True
+    _log.info("=== VeTube iniciado (%s, Python %s) ===",
+              sys.platform, sys.version.split()[0])
+
+
+def _instalar_captura_excepciones():
+    """Registra en el log cualquier excepción no controlada, incluidos los hilos."""
+    excepthook_previo = sys.excepthook
+
+    def manejar_hilo_principal(tipo, valor, traza):
+        if issubclass(tipo, KeyboardInterrupt):
+            excepthook_previo(tipo, valor, traza)
+            return
+        _log.critical("Excepción no controlada", exc_info=(tipo, valor, traza))
+        excepthook_previo(tipo, valor, traza)
+
+    sys.excepthook = manejar_hilo_principal
+
+    # threading.excepthook existe desde Python 3.8; los servicios de VeTube corren
+    # en hilos (Kick, TikTok, Discord, actualizador...), así que capturar aquí es clave.
+    threading_previo = threading.excepthook
+
+    def manejar_hilo_secundario(args):
+        if issubclass(args.exc_type, KeyboardInterrupt):
+            threading_previo(args)
+            return
+        _log.critical(
+            "Excepción no controlada en el hilo %s",
+            getattr(args.thread, "name", "?"),
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+        threading_previo(args)
+
+    threading.excepthook = manejar_hilo_secundario

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -12,12 +12,17 @@ import os
 import sys
 import threading
 
-# Bibliotecas de terceros que generan mucho ruido en DEBUG: las bajamos a WARNING
-# para que el archivo de log siga siendo legible y útil para diagnosticar.
+# Bibliotecas de terceros muy verbosas (peticiones HTTP, latidos de websocket...):
+# las bajamos a WARNING para que el archivo de log siga siendo legible.
 _LIBRERIAS_RUIDOSAS = (
     "httpx", "httpcore", "urllib3", "asyncio", "PIL",
-    "comtypes", "websocket", "websockets", "TikTokLive",
+    "comtypes", "websocket", "websockets",
 )
+
+# Nuestros propios módulos: los ponemos en DEBUG para tener diagnóstico fino
+# (p. ej. los pasos del actualizador), mientras el resto queda en INFO. Se hace
+# con lista explícita porque los loggers de VeTube no comparten un prefijo común.
+_LOGGERS_VETUBE = ("vetube", "update", "updater", "keyboard_handler")
 
 _configurado = False
 _log = logging.getLogger("vetube")
@@ -32,7 +37,7 @@ def carpeta_logs():
     return os.path.join(base, "logs")
 
 
-def configurar_logs(nivel=logging.DEBUG):
+def configurar_logs(nivel=logging.INFO):
     """Configura el logger raíz una sola vez. Seguro de llamar varias veces."""
     global _configurado
     if _configurado:
@@ -71,6 +76,9 @@ def configurar_logs(nivel=logging.DEBUG):
 
     for nombre in _LIBRERIAS_RUIDOSAS:
         logging.getLogger(nombre).setLevel(logging.WARNING)
+
+    for nombre in _LOGGERS_VETUBE:
+        logging.getLogger(nombre).setLevel(logging.DEBUG)
 
     _instalar_captura_excepciones()
 


### PR DESCRIPTION
## Qué hace

Añade un sistema de logs central a VeTube, en la línea de lo que hablamos: a raíz del usuario al que no se le descargaba la actualización, vimos que el programa **no guardaba ningún log**, así que cuando algo falla nos quedamos a ciegas.

Hasta ahora los errores se imprimían por consola (invisible en el build congelado) o **morían en silencio en los hilos secundarios**. Los servicios de VeTube corren casi todos en hilos (Kick, TikTok, Discord, actualizador…), y una excepción no controlada en un hilo no la captura `sys.excepthook`, por lo que desaparecía sin dejar rastro.

## Cambios

- **Nuevo módulo `utils/logging_setup.py`**:
  - Archivo rotativo en **`logs/vetube.log`** (carpeta `logs` junto al programa), en UTF-8. Rota a ~1 MB con 5 copias, así que nunca crece sin control (tope ~6 MB).
  - Captura las excepciones no controladas del **hilo principal** (`sys.excepthook`) **y de los hilos secundarios** (`threading.excepthook`), que es la clave para el caso del actualizador y de los servicios.
  - Baja a WARNING el ruido de algunas librerías de terceros (httpx, urllib3, asyncio…) para que el log siga siendo legible.
  - Está pensado para **no romper nunca el arranque**: si no se puede crear la carpeta o el archivo (permisos, disco lleno…), la app sigue funcionando sin log.
- **`run_main_window.py`**: se configura el log antes de cualquier otro import, para capturar también los errores de arranque.
- **`update.py`**: `perform_update` ahora registra cualquier fallo de descarga/instalación en vez de morir en silencio en su hilo. Este es justo el caso del usuario que no podía actualizar: a partir de ahora deja una línea en el log que podemos mirar.
- **`.gitignore`**: ignora la carpeta `logs/`.

## Notas

- Es un PR pequeño de robustez, en la línea del #80. No añade ninguna cadena visible nueva, así que **no toca los catálogos de traducción**.
- Es la **base reutilizable**: a partir de aquí se pueden ir migrando los `print(...)` sueltos del resto del programa a logs de verdad, servicio por servicio, como comentaste ("logs en general en todo el programa").
- Pendiente para un lote siguiente (ya con i18n): **mostrar un aviso al usuario** cuando la actualización falla, en lugar de solo registrarlo.

## Pruebas

Probado con el venv (sin arrancar la interfaz): el archivo se crea correctamente, los acentos salen bien en UTF-8, no se duplican los handlers al configurar dos veces, y una excepción lanzada en un hilo secundario queda registrada con su traza completa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
