### PR TITLE
Migra los print() de los servicios al sistema de logs

### DIFF
--- a/servicios/YouTubeRealDataTime.py
+++ b/servicios/YouTubeRealDataTime.py
@@ -1,5 +1,6 @@
 import pytchat, wx, json, threading
 from exchange import exchange
+from logging import getLogger
 from utils.play_mp4 import extract_stream_url
 from globals import data_store
 from globals.resources import rutasonidos
@@ -8,6 +9,8 @@ from setup import player, reader
 from controller.chat_controller import ChatController
 from controller.media_controller import MediaController
 from servicios.estadisticas_manager import EstadisticasManager
+
+logger = getLogger(__name__)
 
 class YouTubeRealTimeService:
     def __init__(self, url, frame, plataforma, title=None, chat_controller=None):
@@ -45,7 +48,7 @@ class YouTubeRealTimeService:
         if video_url:
             self.media_controller = MediaController(url=video_url, state_callback=self.chat_controller.chat_dialog.on_media_player_state_change)
             self.chat_controller.set_media_controller(self.media_controller)
-            print(video_url)
+            logger.debug("URL de video: %s", video_url)
     def recibir(self):
         if data_store.dst:
             self.translator = translator.TranslatorWrapper()

--- a/servicios/YouTubeRealDataTime.py
+++ b/servicios/YouTubeRealDataTime.py
@@ -1,6 +1,7 @@
 import pytchat, wx, json, threading
 from exchange import exchange
 from logging import getLogger
+from urllib.parse import urlsplit
 from utils.play_mp4 import extract_stream_url
 from globals import data_store
 from globals.resources import rutasonidos
@@ -48,7 +49,9 @@ class YouTubeRealTimeService:
         if video_url:
             self.media_controller = MediaController(url=video_url, state_callback=self.chat_controller.chat_dialog.on_media_player_state_change)
             self.chat_controller.set_media_controller(self.media_controller)
-            logger.debug("URL de video: %s", video_url)
+            # Solo el host: la URL completa lleva parámetros firmados (IP del usuario)
+            # y el log está pensado para compartirse al diagnosticar.
+            logger.debug("URL de video extraída (host: %s)", urlsplit(video_url).netloc)
     def recibir(self):
         if data_store.dst:
             self.translator = translator.TranslatorWrapper()
@@ -122,6 +125,7 @@ class YouTubeRealTimeService:
                             if data_store.config['reader'] and data_store.config['unread'][5]:
                                 wx.CallAfter(reader.leer_mensaje, full_message)
         except Exception as e:
+            logger.exception("Error fatal en la recepción del chat en tiempo real de YouTube")
             wx.CallAfter(self.chat_controller.notificar_error, str(e))
         finally:
             if self.chat: self.chat.terminate()

--- a/servicios/discord.py
+++ b/servicios/discord.py
@@ -1,10 +1,13 @@
 import asyncio, threading, re, wx
 import discord
+from logging import getLogger
 from globals import data_store
 from globals.resources import rutasonidos
 from setup import reader, player
 from utils import translator
 from utils.network import network_manager
+
+logger = getLogger(__name__)
 
 def extraer_id_canal(url):
     """Devuelve el id del canal si la URL es un enlace de canal de Discord
@@ -65,14 +68,14 @@ class ServicioDiscord:
             self.loop.run_forever()
         except Exception as e:
             if self.is_running:
-                print(f"Error fatal en el hilo de conexión de Discord: {e}")
+                logger.exception("Error fatal en el hilo de conexión de Discord")
                 wx.CallAfter(self.chat_controller.notificar_error, str(e))
         finally:
             try:
                 self.loop.close()
             except Exception:
                 pass
-            print("Hilo de Discord finalizado.")
+            logger.info("Hilo de Discord finalizado.")
 
     async def _conectar(self):
         try:
@@ -90,7 +93,7 @@ class ServicioDiscord:
                 self.detener()
         except Exception as e:
             if self.is_running:
-                print(f"Error de conexión con Discord: {e}")
+                logger.exception("Error de conexión con Discord")
                 wx.CallAfter(self.chat_controller.notificar_error, str(e))
                 self.detener()
 
@@ -114,8 +117,8 @@ class ServicioDiscord:
             title = f"#{channel.name} ({channel.guild.name})"
             wx.CallAfter(self.chat_controller.agregar_titulo, title)
             wx.CallAfter(self.chat_controller.chat_dialog.update_chat_page_title, self.chat_controller, title)
-        except Exception as e:
-            print(f"Error al acceder al canal de Discord: {e}")
+        except Exception:
+            logger.exception("Error al acceder al canal de Discord")
             wx.CallAfter(reader.leer_sapi, _("No se encontró el canal de Discord. Comprueba que el bot está invitado al servidor y que el enlace del canal es correcto."))
             self.detener()
 
@@ -155,11 +158,11 @@ class ServicioDiscord:
         if not self.is_running:
             return
         self.is_running = False
-        print("Deteniendo servicio de Discord...")
+        logger.info("Deteniendo servicio de Discord...")
 
         if self.loop and self.loop.is_running():
             if self.client:
                 asyncio.run_coroutine_threadsafe(self.client.close(), self.loop)
             self.loop.call_soon_threadsafe(self.loop.stop)
 
-        print("Servicio de Discord detenido completamente.")
+        logger.info("Servicio de Discord detenido completamente.")

--- a/servicios/estadisticas_manager.py
+++ b/servicios/estadisticas_manager.py
@@ -1,4 +1,7 @@
 import json
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 class EstadisticasManager:
     def __init__(self):
@@ -87,7 +90,7 @@ class EstadisticasManager:
 
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(stats_a_guardar, f, ensure_ascii=False, indent=4)
-        print(f"Estadísticas guardadas en {file_path}")
+        logger.info("Estadísticas guardadas en %s", file_path)
 
 
     def total_mensajes(self):

--- a/servicios/kick.py
+++ b/servicios/kick.py
@@ -1,10 +1,13 @@
 import asyncio, threading, subprocess, os, platform, wx, kick
+from logging import getLogger
 from globals import data_store
 from globals.resources import rutasonidos
 from setup import reader, player
 from controller.media_controller import MediaController
 from utils.play_mp4 import extract_stream_url
 from utils import translator
+
+logger = getLogger(__name__)
 
 class ServicioKick:
     def __init__(self, main_controller, url, frame, plataforma, chat_controller):
@@ -36,7 +39,7 @@ class ServicioKick:
         bypass_executable = os.path.join(path_to_arch_dir, f"bypass{arch}.exe")
 
         if not os.path.exists(bypass_executable):
-            print(f"Error: No se encuentra el archivo '{bypass_executable}'.")
+            logger.error("No se encuentra el archivo '%s'.", bypass_executable)
             wx.CallAfter(reader.leer_sapi, _("error_bypass_no_encontrado"))
             return False
 
@@ -52,8 +55,8 @@ class ServicioKick:
                 errors='replace',
                 creationflags=creation_flags
             )
-        except Exception as e:
-            print(f"Error al intentar ejecutar {bypass_executable}: {e}")
+        except Exception:
+            logger.exception("Error al intentar ejecutar %s", bypass_executable)
             return False
 
         for line in iter(self.bypass_process.stdout.readline, ''):
@@ -82,12 +85,12 @@ class ServicioKick:
             self.loop.run_forever()
         except Exception as e:
             if self.is_running:
-                print(f"Error fatal en el hilo de conexión de Kick: {e}")
+                logger.exception("Error fatal en el hilo de conexión de Kick")
                 wx.CallAfter(self.chat_controller.notificar_error, str(e))
         finally:
             if self.loop.is_running():
                 self.loop.close()
-            print("Hilo de Kick finalizado.")
+            logger.info("Hilo de Kick finalizado.")
 
     def _add_listeners(self):
         self.client.event(self.on_ready)
@@ -111,8 +114,8 @@ class ServicioKick:
             if video_url and not self.media_controller:
                 self.media_controller = MediaController(url=video_url, state_callback=self.chat_controller.chat_dialog.on_media_player_state_change)
                 self.chat_controller.set_media_controller(self.media_controller)
-        except Exception as e:
-            print(f"Error al conectar al chatroom de Kick: {e}")
+        except Exception:
+            logger.exception("Error al conectar al chatroom de Kick")
             wx.CallAfter(reader.leer_sapi, _("error_conectar_kick_chatroom"))
             self.detener()
 
@@ -170,7 +173,7 @@ class ServicioKick:
         if not self.is_running:
             return
         self.is_running = False
-        print("Deteniendo servicio de Kick...")
+        logger.info("Deteniendo servicio de Kick...")
 
         if self.media_controller:
             self.media_controller.release()
@@ -183,15 +186,15 @@ class ServicioKick:
 
         if self.bypass_process:
             try:
-                print("Terminando proceso de bypass...")
+                logger.debug("Terminando proceso de bypass...")
                 self.bypass_process.terminate()
                 self.bypass_process.wait()
-                print("Proceso de bypass terminado.")
-            except Exception as e:
-                print(f"Error al terminar el proceso de bypass: {e}")
+                logger.debug("Proceso de bypass terminado.")
+            except Exception:
+                logger.exception("Error al terminar el proceso de bypass")
             self.bypass_process = None
-        
-        print("Servicio de Kick detenido completamente.")
+
+        logger.info("Servicio de Kick detenido completamente.")
 
     async def _refrescar_espectadores_loop(self):
         while self.is_running:
@@ -208,8 +211,8 @@ class ServicioKick:
                     wx.CallAfter(self.chat_controller.chat_dialog.update_chat_page_title, self.chat_controller, title)
                 else:
                     break
-            except Exception as e:
-                print(f"Error al refrescar espectadores de Kick: {e}")
+            except Exception:
+                logger.exception("Error al refrescar espectadores de Kick")
                 break
             
             await asyncio.sleep(10)

--- a/servicios/sala.py
+++ b/servicios/sala.py
@@ -1,4 +1,5 @@
 import wx
+from logging import getLogger
 from helpers.timer import Timer
 from helpers.playroom_helper import PlayroomHelper
 from controller.chat_controller import ChatController
@@ -8,6 +9,8 @@ from utils import translator
 from setup import player,reader
 from controller.chat_controller import ChatController
 from servicios.estadisticas_manager import EstadisticasManager
+
+logger = getLogger(__name__)
 
 class ServicioSala:
     def __init__(self, main_controller, url, frame, plataforma, chat_controller):
@@ -35,6 +38,7 @@ class ServicioSala:
             wx.CallAfter(self.chat_controller.agregar_titulo, title)
             wx.CallAfter(self.chat_controller.chat_dialog.update_chat_page_title, self.chat_controller, title)
         except Exception as e:
+            logger.exception("Error al iniciar el chat de la sala de juegos")
             wx.CallAfter(self.chat_controller.notificar_error, str(e))
 
     def detener(self):
@@ -68,4 +72,5 @@ class ServicioSala:
             # el Timer seguiría fallando cada medio segundo y mostraría errores sin fin.
             if not self._detener:
                 self.detener()
+                logger.exception("Error fatal en la recepción del chat de la sala de juegos")
                 wx.CallAfter(self.chat_controller.notificar_error, str(e))

--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -59,6 +59,7 @@ class ServicioTiktok:
             except RuntimeError:
                 pass  # un stop() rezagado de detener() puede vaciar el bucle antes de tiempo
             self.loop.close()
+            logger.info("Hilo de TikTok finalizado.")
 
     async def _initialize_and_run_client(self):
         try:
@@ -69,7 +70,7 @@ class ServicioTiktok:
             self._add_listeners()
             await self._run_client_async()
         except Exception as e:
-            logger.exception("Error during client initialization")
+            logger.exception("Error al inicializar el cliente de TikTok")
             wx.CallAfter(self.chat_controller.notificar_error, str(e))
             self.detener()
 
@@ -108,6 +109,7 @@ class ServicioTiktok:
             self.media_controller.release()
         if self.is_running and self.loop and self.loop.is_running():
             self.is_running = False
+            logger.info("Deteniendo servicio de TikTok...")
             if self.chat:
                 asyncio.run_coroutine_threadsafe(self.chat.disconnect(), self.loop)
             self.loop.call_soon_threadsafe(self.loop.stop)

--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -1,5 +1,6 @@
-import json, threading, asyncio, wx, traceback, time
+import json, threading, asyncio, wx, time
 from exchange import exchange
+from logging import getLogger
 from TikTokLive.client.client import TikTokLiveClient
 from TikTokLive.events import CommentEvent, GiftEvent, DisconnectEvent, ConnectEvent, LikeEvent, JoinEvent, FollowEvent, ShareEvent, RoomUserSeqEvent, EnvelopeEvent, EmoteChatEvent,LiveEndEvent
 from globals import data_store
@@ -8,6 +9,8 @@ from utils import translator,funciones
 from setup import player,reader
 from controller.chat_controller import ChatController
 from servicios.estadisticas_manager import EstadisticasManager
+
+logger = getLogger(__name__)
 
 class ServicioTiktok:
     def __init__(self, main_controller, url, frame, plataforma, chat_controller):
@@ -41,9 +44,8 @@ class ServicioTiktok:
             tarea_principal = self.loop.create_task(self._initialize_and_run_client())
             tarea_principal.add_done_callback(parar_bucle)
             self.loop.run_forever()
-        except Exception as e:
-            print(f"Error fatal en el hilo de conexión: {e}")
-            traceback.print_exc()
+        except Exception:
+            logger.exception("Error fatal en el hilo de conexión")
         finally:
             if tarea_principal is not None:
                 tarea_principal.remove_done_callback(parar_bucle)
@@ -67,8 +69,7 @@ class ServicioTiktok:
             self._add_listeners()
             await self._run_client_async()
         except Exception as e:
-            print(f"Error during client initialization: {e}")
-            traceback.print_exc()
+            logger.exception("Error during client initialization")
             wx.CallAfter(self.chat_controller.notificar_error, str(e))
             self.detener()
 
@@ -98,8 +99,7 @@ class ServicioTiktok:
                 break
             except Exception as e:
                 if self.is_running:
-                    print(f"Error en el bucle del cliente: {e}.")
-                    traceback.print_exc()
+                    logger.exception("Error en el bucle del cliente")
                     wx.CallAfter(self.chat_controller.notificar_error, str(e))
                     self.detener()
 
@@ -120,8 +120,8 @@ class ServicioTiktok:
                 from controller.media_controller import MediaController
                 self.media_controller = MediaController(url=video_url, state_callback=self.chat_controller.chat_dialog.on_media_player_state_change)
                 self.chat_controller.set_media_controller(self.media_controller)
-        except Exception as e:
-            print(f"Error al iniciar la reproducción de video en TikTok: {e}")
+        except Exception:
+            logger.exception("Error al iniciar la reproducción de video en TikTok")
 
     def _add_listeners(self):
         self.chat.add_listener(ConnectEvent, self.on_connect)

--- a/servicios/twich.py
+++ b/servicios/twich.py
@@ -1,5 +1,6 @@
 import json, threading, re, wx
 from exchange import exchange
+from logging import getLogger
 from chat_downloader import ChatDownloader
 from globals import data_store
 from globals.resources import rutasonidos
@@ -9,6 +10,8 @@ from setup import player,reader
 from controller.chat_controller import ChatController
 from controller.media_controller import MediaController
 from servicios.estadisticas_manager import EstadisticasManager
+
+logger = getLogger(__name__)
 
 class ServicioTwich:
     def __init__(self, main_controller, url, frame, plataforma, chat_controller):
@@ -41,8 +44,8 @@ class ServicioTwich:
             if video_url:
                 self.media_controller = MediaController(url=video_url, state_callback=self.chat_controller.chat_dialog.on_media_player_state_change)
                 self.chat_controller.set_media_controller(self.media_controller)
-        except Exception as e:
-            print(f"Error al iniciar la reproducción de video en Twitch: {e}")
+        except Exception:
+            logger.exception("Error al iniciar la reproducción de video en Twitch")
 
     def recibir(self):
         try:

--- a/servicios/twich.py
+++ b/servicios/twich.py
@@ -158,5 +158,6 @@ class ServicioTwich:
                     if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][0]: player.play(rutasonidos[0])
                     if data_store.config['reader'] and data_store.config['unread'][0]: reader.leer_mensaje(full_message)
         except Exception as e:
+            logger.exception("Error fatal en la recepción del chat de Twitch")
             wx.CallAfter(self.chat_controller.notificar_error, str(e))
 

--- a/servicios/youtube.py
+++ b/servicios/youtube.py
@@ -168,6 +168,7 @@ class ServicioYouTube:
                         wx.CallAfter(self.chat_controller.agregar_mensaje_verificado, f"{author_name}: {msg}")
                         if data_store.config['reader'] and data_store.config['unread'][5]: wx.CallAfter(reader.leer_mensaje, f'{author_name}: {msg}')
         except Exception as e:
+            logger.exception("Error fatal en la recepción del chat de YouTube")
             wx.CallAfter(self.chat_controller.notificar_error, str(e))
 
     def iniciar_refresco_espectadores(self):

--- a/servicios/youtube.py
+++ b/servicios/youtube.py
@@ -1,5 +1,6 @@
 import json, threading, time, wx
 from exchange import exchange
+from logging import getLogger
 from chat_downloader import ChatDownloader
 from globals import data_store
 from globals.resources import rutasonidos
@@ -9,6 +10,8 @@ from setup import player,reader
 from controller.chat_controller import ChatController
 from controller.media_controller import MediaController
 from servicios.estadisticas_manager import EstadisticasManager
+
+logger = getLogger(__name__)
 
 class ServicioYouTube:
     def __init__(self, main_controller, url, frame, plataforma, chat_controller):
@@ -56,8 +59,8 @@ class ServicioYouTube:
             if video_url:
                 self.media_controller = MediaController(url=video_url, state_callback=self.chat_controller.chat_dialog.on_media_player_state_change)
                 self.chat_controller.set_media_controller(self.media_controller)
-        except Exception as e:
-            print(f"Error al iniciar la reproducción de video en YouTube: {e}")
+        except Exception:
+            logger.exception("Error al iniciar la reproducción de video en YouTube")
 
     def recibir(self):
         try:

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -21,9 +21,15 @@ _LIBRERIAS_RUIDOSAS = (
 
 # Nuestros propios módulos: los ponemos en DEBUG para tener diagnóstico fino
 # (p. ej. los pasos del actualizador), mientras el resto queda en INFO. Se hace
-# con lista explícita porque los loggers de VeTube no comparten un prefijo común.
-# "servicios" cubre por jerarquía a todos sus submódulos (servicios.kick, etc.).
-_LOGGERS_VETUBE = ("vetube", "update", "updater", "keyboard_handler", "servicios")
+# con lista explícita porque los loggers históricos ("update", "keyboard_handler"...)
+# no comparten un prefijo común. Cada paquete cubre por jerarquía a todos sus
+# submódulos (p. ej. "servicios" -> servicios.kick), de modo que los módulos que
+# se vayan migrando a getLogger(__name__) quedan en DEBUG sin tocar esta lista.
+_LOGGERS_VETUBE = (
+    "vetube", "update", "updater", "keyboard_handler",
+    "servicios", "utils", "players", "helpers", "TTS",
+    "exchange", "controller", "ui", "globals",
+)
 
 _configurado = False
 _log = logging.getLogger("vetube")

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -22,7 +22,8 @@ _LIBRERIAS_RUIDOSAS = (
 # Nuestros propios módulos: los ponemos en DEBUG para tener diagnóstico fino
 # (p. ej. los pasos del actualizador), mientras el resto queda en INFO. Se hace
 # con lista explícita porque los loggers de VeTube no comparten un prefijo común.
-_LOGGERS_VETUBE = ("vetube", "update", "updater", "keyboard_handler")
+# "servicios" cubre por jerarquía a todos sus submódulos (servicios.kick, etc.).
+_LOGGERS_VETUBE = ("vetube", "update", "updater", "keyboard_handler", "servicios")
 
 _configurado = False
 _log = logging.getLogger("vetube")


### PR DESCRIPTION
## Resumen

Segundo paso del sistema de logs (#81): migra los `print()` de la carpeta `servicios/` al log central `logs/vetube.log`, para que los errores de los servicios dejen rastro diagnosticable también en el build congelado, donde los `print` no se ven.

## Cambios

- **25 `print()` migrados** en 7 archivos: `kick.py` (11), `discord.py` (6), `tiktok.py` (4), `youtube.py`, `twich.py`, `YouTubeRealDataTime.py` y `estadisticas_manager.py` (1 cada uno).
- **Errores dentro de `except` → `logger.exception(...)`**: ahora queda el mensaje **y la traza completa** en el log; antes solo se imprimía `{e}` y la traza se perdía.
- **Mensajes de ciclo de vida** («Deteniendo servicio de Kick...», «Hilo de Discord finalizado.») → `logger.info(...)`; los micro-pasos del bypass de Kick y la URL de vídeo de depuración → `logger.debug(...)`.
- **`tiktok.py`**: se eliminan los `traceback.print_exc()` y su import, redundantes con `logger.exception`.
- **`utils/logging_setup.py`**: se añade `"servicios"` a `_LOGGERS_VETUBE`; por jerarquía cubre en DEBUG a todos sus submódulos (`servicios.kick`, `servicios.discord`, ...).
- Son mensajes técnicos internos, no visibles en la interfaz → **sin i18n**, igual que en #81.

## Pruebas

- `py_compile` sobre los 8 archivos: OK.
- Los 7 módulos se importan sin errores con el venv de la app.
- Prueba funcional: tras `configurar_logs()`, los loggers `servicios.*` quedan en DEBUG (heredado) y una excepción capturada escribe mensaje + traceback en `logs/vetube.log` (verificados los niveles ERROR, DEBUG e INFO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
