### PR TITLE
Corrige la fuga del event loop en el servicio de Kick

### DIFF
--- a/servicios/kick.py
+++ b/servicios/kick.py
@@ -88,8 +88,10 @@ class ServicioKick:
                 logger.exception("Error fatal en el hilo de conexión de Kick")
                 wx.CallAfter(self.chat_controller.notificar_error, str(e))
         finally:
-            if self.loop.is_running():
+            try:
                 self.loop.close()
+            except Exception:
+                pass
             logger.info("Hilo de Kick finalizado.")
 
     def _add_listeners(self):


### PR DESCRIPTION
## Problema

Es el hallazgo preexistente que señalé en la auto-revisión de la PR #82: el event loop de asyncio del servicio de Kick nunca se cierra, y se fuga un `ProactorEventLoop` (con sus recursos internos) por cada sesión de Kick.

## Causa

En el `finally` de `_start_async_loop` (`servicios/kick.py`), la condición está invertida:

```python
finally:
    if self.loop.is_running():
        self.loop.close()
```

`close()` solo se permite con el bucle **parado** (si corriera, lanzaría `RuntimeError`), y en el `finally` el bucle ya está siempre parado (se llega ahí cuando `run_forever()` retornó, cuando el bypass falló antes de arrancarlo, o tras una excepción fatal). Resultado: la condición nunca es cierta y `close()` no se ejecuta jamás.

## Solución

El mismo patrón que ya usa `discord.py` en su `finally`: `close()` incondicional protegido por `try/except`.

```python
finally:
    try:
        self.loop.close()
    except Exception:
        pass
    logger.info("Hilo de Kick finalizado.")
```

Verifiqué además que `detener()` sigue siendo seguro con el bucle cerrado: su guarda `self.loop.is_running()` devuelve `False` sobre un bucle cerrado (no lanza), así que un `detener()` tardío no crashea.

## Pruebas

Banco de simulación con el código real del servicio (hilo real, bucle real, cliente de Kick y bypass simulados), como en las PR #59/#64/#75:

- **Antes del fix: 8/11** — el bucle quedaba sin cerrar en los 3 caminos de salida (parada normal, fallo del bypass, excepción fatal).
- **Después del fix: 11/11** — bucle cerrado en los 3 caminos, «Hilo de Kick finalizado.» se sigue registrando (el `finally` llega al final), `notificar_error` sigue difiriéndose con `wx.CallAfter`, y `detener()` tardío sobre bucle cerrado no lanza excepción y aun así termina el proceso del bypass.
- `py_compile` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
