### PR TITLE
Completa el patron wx.CallAfter en Twitch, Sala y YouTube (Sprint 2 del audit)

### DIFF
--- a/servicios/YouTubeRealDataTime.py
+++ b/servicios/YouTubeRealDataTime.py
@@ -66,7 +66,7 @@ class YouTubeRealTimeService:
                     if self._detener: break
                     author_name = c.author.name
                     msg = c.message
-                    self.estadisticas_manager.agregar_mensaje(author_name)
+                    wx.CallAfter(self.estadisticas_manager.agregar_mensaje, author_name)
                     if data_store.dst and self.translator: msg = self.translator.translate(text=msg, target=data_store.dst)
                     message_type = 'general'
                     if c.author.isChatOwner: message_type = 'propietario'
@@ -85,7 +85,7 @@ class YouTubeRealTimeService:
                             
                             full_message = f"{amount} {currency}, {author_name}: {msg}"
                             if data_store.config['sonidos'] and data_store.config['listasonidos'][3]:
-                                player.play(rutasonidos[3])
+                                wx.CallAfter(player.play, rutasonidos[3])
                             wx.CallAfter(self.chat_controller.agregar_mensaje_donacion, full_message)
                             if data_store.config['reader'] and data_store.config['unread'][3]:
                                 wx.CallAfter(reader.leer_mensaje, full_message)
@@ -96,14 +96,14 @@ class YouTubeRealTimeService:
                     if message_type == 'general':
                         if data_store.config['eventos'][0] and data_store.config['categorias'][0] and hasattr(self.chat_controller.ui, 'list_box_general'):
                             if data_store.config['sonidos'] and data_store.config['listasonidos'][0]:
-                                player.play(rutasonidos[0])
+                                wx.CallAfter(player.play, rutasonidos[0])
                             wx.CallAfter(self.chat_controller.agregar_mensaje_general, full_message)
                             if data_store.config['reader'] and data_store.config['unread'][0]:
                                 wx.CallAfter(reader.leer_mensaje, full_message)
                     elif message_type == 'miembro':
                         if data_store.config['eventos'][1] and data_store.config['categorias'][2] and hasattr(self.chat_controller.ui, 'list_box_miembros'):
                             if data_store.config['sonidos'] and data_store.config['listasonidos'][1]:
-                                player.play(rutasonidos[1])
+                                wx.CallAfter(player.play, rutasonidos[1])
                             wx.CallAfter(self.chat_controller.agregar_mensaje_miembro, full_message)
                             if data_store.config['reader'] and data_store.config['unread'][1]:
                                 wx.CallAfter(reader.leer_mensaje, full_message)
@@ -111,16 +111,16 @@ class YouTubeRealTimeService:
                         if data_store.config['eventos'][4] and data_store.config['categorias'][4] and hasattr(self.chat_controller.ui, 'list_box_moderadores'):
                             if data_store.config['sonidos'] and data_store.config['listasonidos'][4]:
                                 if message_type == 'moderador':
-                                    player.play(rutasonidos[4])
+                                    wx.CallAfter(player.play, rutasonidos[4])
                                 if message_type == 'propietario':
-                                    player.play(rutasonidos[7])
+                                    wx.CallAfter(player.play, rutasonidos[7])
                             wx.CallAfter(self.chat_controller.agregar_mensaje_moderador, full_message)
                             if data_store.config['reader'] and data_store.config['unread'][4]:
                                 wx.CallAfter(reader.leer_mensaje, full_message)
                     elif message_type == 'verificado':
                         if data_store.config['eventos'][5] and data_store.config['categorias'][5] and hasattr(self.chat_controller.ui, 'list_box_verificados'):
                             if data_store.config['sonidos'] and data_store.config['listasonidos'][5]:
-                                player.play(rutasonidos[5])
+                                wx.CallAfter(player.play, rutasonidos[5])
                             wx.CallAfter(self.chat_controller.agregar_mensaje_verificado, full_message)
                             if data_store.config['reader'] and data_store.config['unread'][5]:
                                 wx.CallAfter(reader.leer_mensaje, full_message)

--- a/servicios/sala.py
+++ b/servicios/sala.py
@@ -51,22 +51,22 @@ class ServicioSala:
         try:
             self.chat.get_new_messages()
             for message in self.chat.new_messages:
-                self.estadisticas_manager.agregar_mensaje(message['author'])
+                wx.CallAfter(self.estadisticas_manager.agregar_mensaje, message['author'])
                 if self._detener: break
                 if message['message']==None: message['message']=''
                 if data_store.dst and self.translator: message['message'] = self.translator.translate(text=message['message'], target=data_store.dst)
                 if (message['type'] == 'private'):
                     if data_store.config['categorias'][2] and hasattr(self.chat_controller.ui, 'list_box_miembros'):
                         if data_store.config['eventos'][1]:
-                            self.chat_controller.agregar_mensaje_miembro(message['author'] +': ' +message['message'])
-                            if data_store.config['reader'] and data_store.config['unread'][1]: reader.leer_mensaje(message['author'] +': ' +message['message'])
-                            if data_store.config['sonidos'] and data_store.config['listasonidos'][2]: player.play(rutasonidos[2])
+                            wx.CallAfter(self.chat_controller.agregar_mensaje_miembro, message['author'] +': ' +message['message'])
+                            if data_store.config['reader'] and data_store.config['unread'][1]: wx.CallAfter(reader.leer_mensaje, message['author'] +': ' +message['message'])
+                            if data_store.config['sonidos'] and data_store.config['listasonidos'][2]: wx.CallAfter(player.play, rutasonidos[2])
                 else:
                     if data_store.config['categorias'][0] and hasattr(self.chat_controller.ui, 'list_box_general'):
                         if data_store.config['eventos'][0]:
-                            self.chat_controller.agregar_mensaje_general(message['author'] +': ' +message['message'])
-                            if data_store.config['reader'] and data_store.config['unread'][0]: reader.leer_mensaje(message['author'] +': ' +message['message'])
-                            if data_store.config['sonidos'] and data_store.config['listasonidos'][0]: player.play(rutasonidos[0])
+                            wx.CallAfter(self.chat_controller.agregar_mensaje_general, message['author'] +': ' +message['message'])
+                            if data_store.config['reader'] and data_store.config['unread'][0]: wx.CallAfter(reader.leer_mensaje, message['author'] +': ' +message['message'])
+                            if data_store.config['sonidos'] and data_store.config['listasonidos'][0]: wx.CallAfter(player.play, rutasonidos[0])
         except Exception as e:
             # Detener el sondeo antes de notificar: si la ventana de la sala se cierra,
             # el Timer seguiría fallando cada medio segundo y mostraría errores sin fin.

--- a/servicios/twich.py
+++ b/servicios/twich.py
@@ -61,7 +61,7 @@ class ServicioTwich:
                 if data_store.dst and self.translator: message['message'] = self.translator.translate(text=message['message'], target=data_store.dst)
 
                 author_name = message['author'].get('display_name', _('Desconocido'))
-                self.estadisticas_manager.agregar_mensaje(author_name)
+                wx.CallAfter(self.estadisticas_manager.agregar_mensaje, author_name)
                 msg = message['message']
                 full_message = f"{author_name}: {msg}"
 
@@ -77,9 +77,9 @@ class ServicioTwich:
                     elif message['message_type'] == 'subscription' and data_store.config['eventos'][2]: sub_message = _("{author_name} se ha suscrito en el nivel {subscription_plan_name} por {cumulative_months} meses!").format(author_name=author_name, subscription_plan_name=message.get('subscription_plan_name', ''), cumulative_months=message.get('cumulative_months', ''))
                     elif message['message_type'] == 'mystery_subscription_gift' and data_store.config['eventos'][2]: sub_message = _("{author_name} regaló una suscripción de nivel {subscription_type} a la comunidad, ¡ha regalado un total de {sender_count} suscripciones!").format(author_name=author_name, subscription_type=message.get('subscription_type', ''), sender_count=message.get('sender_count', ''))
                     elif message['message_type'] == 'subscription_gift' and data_store.config['eventos'][2]: sub_message = _("{author_name} ha regalado una suscripción a {gift_recipient_display_name} en el nivel {subscription_plan_name} por {number_of_months_gifted} meses!").format(author_name=author_name, gift_recipient_display_name=message.get('gift_recipient_display_name', ''), subscription_plan_name=message.get('subscription_plan_name', ''), number_of_months_gifted=message.get('number_of_months_gifted', ''))
-                    self.chat_controller.agregar_mensaje_evento(sub_message)
-                    if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][2]: player.play(rutasonidos[2])
-                    if data_store.config['reader'] and data_store.config['unread'][2]: reader.leer_mensaje(sub_message)
+                    wx.CallAfter(self.chat_controller.agregar_mensaje_evento, sub_message)
+                    if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][2]: wx.CallAfter(player.play, rutasonidos[2])
+                    if data_store.config['reader'] and data_store.config['unread'][2]: wx.CallAfter(reader.leer_mensaje, sub_message)
                     continue
 
                 # Cheer/Bits event
@@ -99,25 +99,25 @@ class ServicioTwich:
                     # Si el mensaje queda vacío después de quitar los Cheers, no poner los dos puntos
                     full_donacion = f"{dinero}, {author_name}" + (f": {clean_msg}" if clean_msg else "")
                     
-                    if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][3]: 
-                        player.play(rutasonidos[3])
-                    self.chat_controller.agregar_mensaje_donacion(full_donacion)
-                    if data_store.config['reader'] and data_store.config['unread'][3]: 
-                        reader.leer_mensaje(full_donacion)
+                    if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][3]:
+                        wx.CallAfter(player.play, rutasonidos[3])
+                    wx.CallAfter(self.chat_controller.agregar_mensaje_donacion, full_donacion)
+                    if data_store.config['reader'] and data_store.config['unread'][3]:
+                        wx.CallAfter(reader.leer_mensaje, full_donacion)
                     continue
 
                 # Regular messages with badges/roles
                 message_sent = False
                 try:
                     if message['author'].get('is_moderator') and data_store.config['eventos'][4] and data_store.config['categorias'][4] and hasattr(self.chat_controller.ui, 'list_box_moderadores'):
-                        self.chat_controller.agregar_mensaje_moderador(full_message)
-                        if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][4]: player.play(rutasonidos[4])
-                        if data_store.config['reader'] and data_store.config['unread'][4]: reader.leer_mensaje(full_message)
+                        wx.CallAfter(self.chat_controller.agregar_mensaje_moderador, full_message)
+                        if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][4]: wx.CallAfter(player.play, rutasonidos[4])
+                        if data_store.config['reader'] and data_store.config['unread'][4]: wx.CallAfter(reader.leer_mensaje, full_message)
                         message_sent = True
                     elif message['author'].get('is_subscriber') and data_store.config['eventos'][1] and data_store.config['categorias'][2] and hasattr(self.chat_controller.ui, 'list_box_miembros'):
-                        self.chat_controller.agregar_mensaje_miembro(full_message)
-                        if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][1]: player.play(rutasonidos[1])
-                        if data_store.config['reader'] and data_store.config['unread'][1]: reader.leer_mensaje(full_message)
+                        wx.CallAfter(self.chat_controller.agregar_mensaje_miembro, full_message)
+                        if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][1]: wx.CallAfter(player.play, rutasonidos[1])
+                        if data_store.config['reader'] and data_store.config['unread'][1]: wx.CallAfter(reader.leer_mensaje, full_message)
                         message_sent = True
                 except KeyError: pass
                 if message_sent: continue
@@ -126,37 +126,37 @@ class ServicioTwich:
                         title = badge.get('title', '')
                         if 'Subscriber' in title:
                             if data_store.config['eventos'][1] and data_store.config['categorias'][2] and hasattr(self.chat_controller.ui, 'list_box_miembros'):
-                                if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][1]: player.play(rutasonidos[1])
-                                self.chat_controller.agregar_mensaje_miembro(full_message)
-                                if data_store.config['reader'] and data_store.config['unread'][1]: reader.leer_mensaje(full_message)
+                                if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][1]: wx.CallAfter(player.play, rutasonidos[1])
+                                wx.CallAfter(self.chat_controller.agregar_mensaje_miembro, full_message)
+                                if data_store.config['reader'] and data_store.config['unread'][1]: wx.CallAfter(reader.leer_mensaje, full_message)
                             message_sent = True
                             break
                         elif 'Moderator' in title:
                             if data_store.config['eventos'][4] and data_store.config['categorias'][4] and hasattr(self.chat_controller.ui, 'list_box_moderadores'):
-                                if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][4]: player.play(rutasonidos[4])
-                                self.chat_controller.agregar_mensaje_moderador(full_message)
-                                if data_store.config['reader'] and data_store.config['unread'][4]: reader.leer_mensaje(full_message)
+                                if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][4]: wx.CallAfter(player.play, rutasonidos[4])
+                                wx.CallAfter(self.chat_controller.agregar_mensaje_moderador, full_message)
+                                if data_store.config['reader'] and data_store.config['unread'][4]: wx.CallAfter(reader.leer_mensaje, full_message)
                             message_sent = True
                             break
                         elif 'Verified' in title:
                             if data_store.config['eventos'][5] and data_store.config['categorias'][5] and hasattr(self.chat_controller.ui, 'list_box_verificados'):
-                                self.chat_controller.agregar_mensaje_verificado(full_message)
-                                if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][5]: player.play(rutasonidos[5])
-                                if data_store.config['reader'] and data_store.config['unread'][5]: reader.leer_mensaje(full_message)
+                                wx.CallAfter(self.chat_controller.agregar_mensaje_verificado, full_message)
+                                if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][5]: wx.CallAfter(player.play, rutasonidos[5])
+                                if data_store.config['reader'] and data_store.config['unread'][5]: wx.CallAfter(reader.leer_mensaje, full_message)
                             message_sent = True
                             break
                     else:
                         if data_store.config['eventos'][0] and data_store.config['categorias'][0] and hasattr(self.chat_controller.ui, 'list_box_general'):
-                            if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][0]: player.play(rutasonidos[0])
-                            self.chat_controller.agregar_mensaje_general(full_message)
-                            if data_store.config['reader'] and data_store.config['unread'][0]: reader.leer_mensaje(full_message)
+                            if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][0]: wx.CallAfter(player.play, rutasonidos[0])
+                            wx.CallAfter(self.chat_controller.agregar_mensaje_general, full_message)
+                            if data_store.config['reader'] and data_store.config['unread'][0]: wx.CallAfter(reader.leer_mensaje, full_message)
                             message_sent = True
                 if message_sent: continue
                 # Default to general
                 if data_store.config['eventos'][0] and data_store.config['categorias'][0] and hasattr(self.chat_controller.ui, 'list_box_general'):
-                    self.chat_controller.agregar_mensaje_general(full_message)
-                    if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][0]: player.play(rutasonidos[0])
-                    if data_store.config['reader'] and data_store.config['unread'][0]: reader.leer_mensaje(full_message)
+                    wx.CallAfter(self.chat_controller.agregar_mensaje_general, full_message)
+                    if data_store.config['sonidos'] and self.chat.status!="past" and data_store.config['listasonidos'][0]: wx.CallAfter(player.play, rutasonidos[0])
+                    if data_store.config['reader'] and data_store.config['unread'][0]: wx.CallAfter(reader.leer_mensaje, full_message)
         except Exception as e:
             logger.exception("Error fatal en la recepción del chat de Twitch")
             wx.CallAfter(self.chat_controller.notificar_error, str(e))

--- a/servicios/youtube.py
+++ b/servicios/youtube.py
@@ -99,7 +99,7 @@ class ServicioYouTube:
                 if data_store.dst and self.translator: message['message'] = self.translator.translate(text=message['message'], target=data_store.dst)
 
                 author_name = message['author']['display_name']
-                self.estadisticas_manager.agregar_mensaje(author_name)
+                wx.CallAfter(self.estadisticas_manager.agregar_mensaje, author_name)
                 msg = message['message']
 
                 # Default message type
@@ -128,7 +128,7 @@ class ServicioYouTube:
                             mensajito=author_name+ _(' se a conectado al chat. ')+t['title']
                             break
                         wx.CallAfter(self.chat_controller.agregar_mensaje_evento, mensajito)
-                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][2]: player.play(rutasonidos[2])
+                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][2]: wx.CallAfter(player.play, rutasonidos[2])
                         if data_store.config['reader'] and data_store.config['unread'][2]: wx.CallAfter(reader.leer_mensaje, mensajito)
                     continue
                 # Construct the message string
@@ -138,7 +138,7 @@ class ServicioYouTube:
                             message['money']['amount'] = exchange.convert(message['money']['amount'], message['money']['currency'])
                             message['money']['currency'] = data_store.divisa
                         full_message = f"{message['money']['amount']} {message['money']['currency']}, {author_name}: {msg}"
-                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][3]: player.play(rutasonidos[3])
+                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][3]: wx.CallAfter(player.play, rutasonidos[3])
                         wx.CallAfter(self.chat_controller.agregar_mensaje_donacion, full_message)
                         if data_store.config['reader'] and data_store.config['unread'][3]: wx.CallAfter(reader.leer_mensaje, full_message)
                     continue
@@ -147,24 +147,24 @@ class ServicioYouTube:
 
                 if message_type == 'general':
                     if data_store.config['eventos'][0] and data_store.config['categorias'][0] and hasattr(self.chat_controller.ui, 'list_box_general'):
-                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][0]: player.play(rutasonidos[0])
+                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][0]: wx.CallAfter(player.play, rutasonidos[0])
                         wx.CallAfter(self.chat_controller.agregar_mensaje_general, full_message)
                         if data_store.config['reader'] and data_store.config['unread'][0]: wx.CallAfter(reader.leer_mensaje, full_message)
                 elif message_type == 'miembro':
                     if data_store.config['eventos'][1] and data_store.config['categorias'][2] and hasattr(self.chat_controller.ui, 'list_box_miembros'):
-                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][1]: player.play(rutasonidos[1])
+                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][1]: wx.CallAfter(player.play, rutasonidos[1])
                         wx.CallAfter(self.chat_controller.agregar_mensaje_miembro, full_message)
                         if data_store.config['reader'] and data_store.config['unread'][1]: wx.CallAfter(reader.leer_mensaje, full_message)
                 elif message_type == 'moderador' or message_type=='propietario':
                     if data_store.config['eventos'][4] and data_store.config['categorias'][4] and hasattr(self.chat_controller.ui, 'list_box_moderadores'):
                         if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][4]:
-                            if message_type=='moderador': player.play(rutasonidos[4])
-                            if message_type=='propietario': player.play(rutasonidos[7])
+                            if message_type=='moderador': wx.CallAfter(player.play, rutasonidos[4])
+                            if message_type=='propietario': wx.CallAfter(player.play, rutasonidos[7])
                         wx.CallAfter(self.chat_controller.agregar_mensaje_moderador, full_message)
                         if data_store.config['reader'] and data_store.config['unread'][4]: wx.CallAfter(reader.leer_mensaje, full_message)
                 elif message_type == 'verificado':
                     if data_store.config['eventos'][5] and data_store.config['categorias'][5] and hasattr(self.chat_controller.ui, 'list_box_verificados'):
-                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][5]: player.play(rutasonidos[5])
+                        if data_store.config['sonidos'] and self.chat.status != "past" and data_store.config['listasonidos'][5]: wx.CallAfter(player.play, rutasonidos[5])
                         wx.CallAfter(self.chat_controller.agregar_mensaje_verificado, f"{author_name}: {msg}")
                         if data_store.config['reader'] and data_store.config['unread'][5]: wx.CallAfter(reader.leer_mensaje, f'{author_name}: {msg}')
         except Exception as e:


### PR DESCRIPTION
## Problema

El patron `wx.CallAfter` (necesario porque `recibir()` corre en un hilo/Timer separado y wx no permite tocar la UI fuera del hilo principal) ya estaba bien aplicado en `tiktok.py` y `kick.py`, pero:

- **`servicios/twich.py`** y **`servicios/sala.py`** no protegian NINGUNA de sus llamadas a `reader.leer_mensaje`, `player.play`, `chat_controller.agregar_mensaje_*` ni `estadisticas_manager.agregar_mensaje` desde su hilo de recepcion.
- **`servicios/youtube.py`** y **`servicios/YouTubeRealDataTime.py`** ya protegian el lector y el `chat_controller`, pero **`player.play` seguia sin envolver** en varios sitios.

Esto es parte del Sprint 2 ("Thread-safety chat") del audit de codigo del proyecto.

## Solucion

Se completa el mismo patron ya usado en `tiktok.py`/`kick.py`: cada llamada individual envuelta en `wx.CallAfter(funcion, argumentos)`. Sin cambios de comportamiento ni de logica, solo se difiere la ejecucion al hilo principal.

## Pruebas

Banco nuevo `C:\Users\HP\vetube_test_thread_safety_callafter.py` (35/35): intercepta `wx.CallAfter` para no ejecutar nada de verdad, y sustituye las funciones reales (`player.play`, `reader.leer_mensaje`, `chat_controller.agregar_mensaje_*`, `estadisticas_manager.agregar_mensaje`) por centinelas que **lanzan una excepcion si se les llama directamente** (fuera de `wx.CallAfter`). Verificado contra el codigo previo (via `git stash`) que el banco SI detecta la falta de envoltura (4/35 antes del fix, 35/35 despues).

Banco existente `vetube_test_crashfixes.py` releido: 29/29, sin regresion.

🤖 Generated with Claude Code