### PR TITLE
Elimina la instanciación duplicada de AjustesController

### DIFF
--- a/controller/menus/main_menu_controller.py
+++ b/controller/menus/main_menu_controller.py
@@ -8,7 +8,6 @@ from ui.dialog_response import response
 from globals import data_store
 from globals.resources import carpeta_voces,codes,codigos_traduccion
 from controller.editor_controller import EditorController
-from controller.ajustes_controller import AjustesController
 from setup import network, reader, player
 from exchange import codes as currency_codes
 from servicios.language_updater import GestorRepositorios
@@ -43,7 +42,6 @@ class MainMenuController:
 
     def mostrar_ajustes(self, event):
         dlg = configuracionDialog(self.frame)
-        AjustesController(dlg)
         resultado = dlg.ShowModal()
         if resultado == wx.ID_OK:
             self.config_dialog = dlg  # Guarda la referencia para usarla en guardar()


### PR DESCRIPTION
## Problema
Al abrir el diálogo de Ajustes, `AjustesController` se instanciaba **dos veces** sobre el mismo diálogo:
1. Dentro de `configuracionDialog.__init__` (`ui/ajustes/__init__.py:122`), donde se guarda como `self.ajustes_controller`.
2. Otra vez en `MainMenuController.mostrar_ajustes` (`controller/menus/main_menu_controller.py`), descartando el resultado sin asignarlo a ninguna variable.

Cada instancia engancha (`Bind`) todos los checkboxes, sliders y botones del diálogo a sus manejadores, además de crear su propio `wx.Timer`. El resultado es que cada control quedaba enlazado por duplicado.

## Impacto
Hoy no se nota nada porque ambos manejadores hacen exactamente lo mismo (escriben el mismo valor en config), así que ejecutar la acción dos veces no cambia el resultado. Pero es un riesgo latente: si en el futuro alguno de esos manejadores dispara algo que debe ocurrir una sola vez (un anuncio de voz, un sonido, etc.), se dispararía dos veces sin que sea evidente por qué. También duplica trabajo innecesario (timer, binds) cada vez que se abren los Ajustes.

## Solución
Se elimina la segunda instanciación en `mostrar_ajustes`, dejando solo la que ya crea `configuracionDialog`. Comportamiento idéntico para el usuario, sin el riesgo latente.

## Pruebas
- `py_compile` sobre el archivo modificado: OK.
- Cambio mínimo (2 líneas eliminadas, 1 archivo), sin lógica nueva que probar en el banco de pruebas.

🤖 Generated with Claude Code