### PR TITLE
Hace que Cancelar/Escape en Ajustes revierta lo aplicado en caliente

### DIFF
--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 from globals.data_store import config
 from globals.resources import rutasonidos,lista_voces,lista_voces_piper,recargar_rutasonidos
 from setup import player,reader
@@ -6,9 +7,22 @@ from TTS.list_voices import piper_list_voices , install_piper_voice
 from controller.piper_downloader_controller import PiperDownloaderController
 from utils.menu_accesible import Accesible
 import wx
+
+logger = getLogger(__name__)
+
 class AjustesController:
+    # Claves que los controles del diálogo escriben en config apenas cambian (en caliente),
+    # sin esperar a Aceptar. Ver revertir_cambios_en_caliente(): con Cancelar/Escape, todas
+    # vuelven al valor que tenían al abrir el diálogo.
+    CLAVES_EN_CALIENTE = [
+        'sapi', 'reader', 'traducir', 'interface', 'updates', 'salir', 'donations',
+        'sonidos', 'directorio', 'sistemaTTS', 'dispositivo', 'voz', 'volume',
+        'tono', 'tono_onecore', 'speed', 'reproducir', 'tiempo', 'volumen', 'cambiovolumen',
+    ]
+
     def __init__(self, dialog):
         self.dialog = dialog
+        self.config_al_abrir = {clave: config.get(clave) for clave in self.CLAVES_EN_CALIENTE}
         self.dialog.instala_voces.SetAccessible(Accesible(self.dialog.instala_voces))
         
         self.play_timer = wx.Timer(self.dialog)
@@ -363,3 +377,70 @@ class AjustesController:
         except Exception:
             pass
         event.Skip()
+
+    def revertir_cambios_en_caliente(self):
+        """Cancelar/Escape: deshace en config y en el lector/reproductor real todo lo que
+        ya se había aplicado en caliente, para que el diálogo quede como al abrirlo.
+        Reutiliza los propios manejadores (cambiar_sintetizador, cambiarVoz, etc.) porque
+        leen los valores desde los widgets del diálogo, no desde el event, así que sirve
+        con event=None una vez que dejamos los widgets en el valor original."""
+        original = self.config_al_abrir
+        cambio_tts = config.get('sistemaTTS') != original['sistemaTTS']
+        cambio_voz = config.get('voz') != original['voz']
+        cambio_volumen = config.get('volume') != original['volume']
+        cambio_tono = (config.get('tono') != original['tono']) or (config.get('tono_onecore') != original['tono_onecore'])
+        cambio_velocidad = config.get('speed') != original['speed']
+        cambio_dispositivo = config.get('dispositivo') != original['dispositivo']
+        cambio_tema = config.get('directorio') != original['directorio']
+
+        for clave in self.CLAVES_EN_CALIENTE:
+            config[clave] = original[clave]
+
+        if cambio_tema:
+            self.dialog.lista_temas.SetStringSelection(config['directorio'])
+            recargar_rutasonidos()
+
+        if cambio_tts:
+            self.dialog.seleccionar_TTS.SetStringSelection(config['sistemaTTS'])
+            self.cambiar_sintetizador(None)
+        elif cambio_voz:
+            try:
+                self.dialog.choice_2.SetSelection(config['voz'])
+            except Exception:
+                pass
+            self.cambiarVoz(None)
+
+        if cambio_volumen:
+            self.dialog.slider_2.SetValue(config['volume'])
+            self.cambiarVolumen(None)
+
+        if cambio_tono:
+            if config['sistemaTTS'] == "onecore":
+                self.dialog.slider_1.SetValue(config.get('tono_onecore', 0.6))
+            else:
+                self.dialog.slider_1.SetValue(config['tono'] + 10)
+            self.cambiarTono(None)
+
+        if cambio_velocidad:
+            self.dialog.slider_3.SetValue(config['speed'] + 10)
+            self.cambiarVelocidad(None)
+
+        if cambio_dispositivo:
+            try:
+                self.dialog.lista_dispositivos.SetSelection(config['dispositivo'] - 1)
+            except Exception:
+                pass
+            # Sin el sonido de confirmación ni el "Hablaré a través de este dispositivo" de
+            # establecer_dispositivo(): un Cancelar silencioso no debe sonar como un cambio aplicado.
+            try:
+                player.setdevice(config['dispositivo'])
+                if config['sistemaTTS'] == "piper" and lista_voces_piper and lista_voces_piper[0] != _("No hay voces instaladas"):
+                    nombres = player.devicenames
+                    dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres)]
+                    valor_str = nombres[config['dispositivo'] - 1]
+                    reader._lector.set_device(reader._lector.find_device_id(valor_str, known_devices=dispositivos_formateados))
+            except Exception:
+                # Puede fallar si el dispositivo guardado desapareció mientras Ajustes estaba
+                # abierto (auriculares desconectados, etc. — mismo caso que setup.py al arrancar).
+                # No debe tumbar el revert ni impedir que se cierre el diálogo.
+                logger.exception("No se pudo restaurar el dispositivo de audio al cancelar Ajustes (dispositivo=%s)", config['dispositivo'])

--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -383,7 +383,10 @@ class AjustesController:
         ya se había aplicado en caliente, para que el diálogo quede como al abrirlo.
         Reutiliza los propios manejadores (cambiar_sintetizador, cambiarVoz, etc.) porque
         leen los valores desde los widgets del diálogo, no desde el event, así que sirve
-        con event=None una vez que dejamos los widgets en el valor original."""
+        con event=None una vez que dejamos los widgets en el valor original. Cada bloque
+        va en su propio try/except: si uno falla (un backend de voz que ya no está
+        disponible, un dispositivo desconectado...) no debe impedir que se reviertan los
+        demás, y no debe fallar en silencio — se registra con logger.exception."""
         original = self.config_al_abrir
         cambio_tts = config.get('sistemaTTS') != original['sistemaTTS']
         cambio_voz = config.get('voz') != original['voz']
@@ -397,39 +400,59 @@ class AjustesController:
             config[clave] = original[clave]
 
         if cambio_tema:
-            self.dialog.lista_temas.SetStringSelection(config['directorio'])
-            recargar_rutasonidos()
+            try:
+                recargar_rutasonidos()
+            except Exception:
+                logger.exception("No se pudo restaurar el tema de sonidos al cancelar Ajustes (directorio=%s)", config['directorio'])
 
         if cambio_tts:
-            self.dialog.seleccionar_TTS.SetStringSelection(config['sistemaTTS'])
-            self.cambiar_sintetizador(None)
+            try:
+                self.dialog.seleccionar_TTS.SetStringSelection(config['sistemaTTS'])
+                self.cambiar_sintetizador(None)
+            except Exception:
+                logger.exception("No se pudo restaurar el sistema TTS al cancelar Ajustes (sistemaTTS=%s)", config['sistemaTTS'])
         elif cambio_voz:
             try:
-                self.dialog.choice_2.SetSelection(config['voz'])
+                lista_voces_actual = lista_voces_piper if config['sistemaTTS'] == "piper" else reader._lector.list_voices()
+                if 0 <= config['voz'] < len(lista_voces_actual):
+                    self.dialog.choice_2.SetSelection(config['voz'])
+                    self.cambiarVoz(None)
+                else:
+                    # SetSelection() con un índice fuera de rango no lanza excepción en wx: no
+                    # basta con un try/except acá, hay que descartar el índice inválido a mano
+                    # para no terminar cargando una voz cualquiera (indexación negativa de Python).
+                    logger.warning(
+                        "No se pudo restaurar la voz al cancelar Ajustes: índice %s fuera de rango (%s voces disponibles)",
+                        config['voz'], len(lista_voces_actual),
+                    )
             except Exception:
-                pass
-            self.cambiarVoz(None)
+                logger.exception("No se pudo restaurar la voz al cancelar Ajustes (voz=%s)", config['voz'])
 
         if cambio_volumen:
-            self.dialog.slider_2.SetValue(config['volume'])
-            self.cambiarVolumen(None)
+            try:
+                self.dialog.slider_2.SetValue(config['volume'])
+                self.cambiarVolumen(None)
+            except Exception:
+                logger.exception("No se pudo restaurar el volumen al cancelar Ajustes (volume=%s)", config['volume'])
 
         if cambio_tono:
-            if config['sistemaTTS'] == "onecore":
-                self.dialog.slider_1.SetValue(config.get('tono_onecore', 0.6))
-            else:
-                self.dialog.slider_1.SetValue(config['tono'] + 10)
-            self.cambiarTono(None)
+            try:
+                if config['sistemaTTS'] == "onecore":
+                    self.dialog.slider_1.SetValue(config.get('tono_onecore', 0.6))
+                else:
+                    self.dialog.slider_1.SetValue(config['tono'] + 10)
+                self.cambiarTono(None)
+            except Exception:
+                logger.exception("No se pudo restaurar el tono al cancelar Ajustes")
 
         if cambio_velocidad:
-            self.dialog.slider_3.SetValue(config['speed'] + 10)
-            self.cambiarVelocidad(None)
+            try:
+                self.dialog.slider_3.SetValue(config['speed'] + 10)
+                self.cambiarVelocidad(None)
+            except Exception:
+                logger.exception("No se pudo restaurar la velocidad al cancelar Ajustes (speed=%s)", config['speed'])
 
         if cambio_dispositivo:
-            try:
-                self.dialog.lista_dispositivos.SetSelection(config['dispositivo'] - 1)
-            except Exception:
-                pass
             # Sin el sonido de confirmación ni el "Hablaré a través de este dispositivo" de
             # establecer_dispositivo(): un Cancelar silencioso no debe sonar como un cambio aplicado.
             try:

--- a/controller/menus/main_menu_controller.py
+++ b/controller/menus/main_menu_controller.py
@@ -43,10 +43,14 @@ class MainMenuController:
     def mostrar_ajustes(self, event):
         dlg = configuracionDialog(self.frame)
         resultado = dlg.ShowModal()
-        if resultado == wx.ID_OK:
-            self.config_dialog = dlg  # Guarda la referencia para usarla en guardar()
-            self.guardar()
-        dlg.Destroy()
+        try:
+            if resultado == wx.ID_OK:
+                self.config_dialog = dlg  # Guarda la referencia para usarla en guardar()
+                self.guardar()
+            else:
+                dlg.ajustes_controller.revertir_cambios_en_caliente()
+        finally:
+            dlg.Destroy()
 
     def restaurar(self, event):
         if response(_("Estás apunto de reiniciar la configuración a sus valores predeterminados, ¿Deseas proceder?"), _("Atención:"))==wx.ID_YES:


### PR DESCRIPTION
## Problema

Revisando el diálogo de Ajustes (a raíz de la #88) apareció otra inconsistencia: Cancelar y Escape solo descartaban las 4 listas con casillas (sonidos/categorías/eventos/no leídos), que se guardan recién al pulsar Aceptar. Todo lo demás -voz, volumen, tono, velocidad, tema de sonidos, dispositivo de audio, y las casillas de General/Chat/Reproducción- escribía en `config` y se aplicaba de verdad en el lector/reproductor apenas se tocaba el control, sin que Cancelar ni Escape lo revirtieran.

Le planteé dos opciones a César: aplicar también esas listas al toque (más chico, sin tocar el resto), o revertir de verdad todo lo aplicado en caliente al Cancelar/Escape (más grande, más delicado de probar, pero más cercano a lo esperado de un diálogo de Ajustes normal). Eligió la segunda.

## Solución

- `AjustesController` guarda `config_al_abrir`, una foto de todas las claves que se aplican en caliente, al construirse (es decir, al abrir el diálogo).
- Nuevo método `revertir_cambios_en_caliente()`: si el diálogo se cierra sin Aceptar, restaura esas claves en `config` y reaplica el valor original al lector/reproductor real, reutilizando los propios manejadores existentes (`cambiar_sintetizador`, `cambiarVoz`, `cambiarVolumen`, `cambiarTono`, `cambiarVelocidad`) en vez de duplicar su lógica.
- Para el dispositivo de audio y el tema de sonidos se replica el mismo efecto pero sin el sonido/frase de confirmación (`cambiardispositivo.mp3`, "Hablaré a través de este dispositivo"), para que Cancelar quede silencioso y no parezca un cambio aplicado a propósito.
- `MainMenuController.mostrar_ajustes()` llama a `revertir_cambios_en_caliente()` cuando `ShowModal()` no devuelve `wx.ID_OK`, y ahora envuelve todo en `try/finally` para garantizar que `dlg.Destroy()` se ejecute pase lo que pase.
- Si el dispositivo de audio guardado dejó de existir mientras Ajustes estaba abierto (mismo caso ya conocido en `setup.py` al arrancar), el revert ya no revienta: se registra con `logger.exception` y sigue el cierre normal del diálogo.

## Pruebas

- `py_compile` sobre ambos archivos: OK.
- Verificación con scripts contra el código real (`configuracionDialog`/`AjustesController` reales dentro de un `wx.App` de fondo, sin mostrar la ventana): volumen, tono, velocidad, tema de sonidos, dispositivo de audio (con varios dispositivos reales) y cambio de sistema TTS (sapi5 ↔ onecore ↔ piper, con carga de voz real incluida) vuelven todos a su valor de apertura tras un Cancelar simulado. También se forzó un dispositivo inválido al revertir para confirmar que ya no lanza excepción.
- Revisión de accesibilidad (agente local): confirmó que el revert silencioso es el comportamiento esperado bajo NVDA, y fue quien detectó el fallo del dispositivo inválido corregido arriba.
- **Pendiente**: prueba en vivo con NVDA por Enzo (el cambio toca voz/audio en caliente, así que prefiere confirmarlo de oído antes de darlo por bueno).

🤖 Generated with Claude Code