### PR TITLE
Tres microcorrecciones de robustez: aviso de actualización, sonido de la sala y cerrojo de TikTok

### DIFF
--- a/controller/main_controller.py
+++ b/controller/main_controller.py
@@ -169,7 +169,6 @@ class MainController:
                         else:
                             wx.MessageBox(_("No se pudo obtener la URL real de TikTok."), _("Error"), wx.ICON_ERROR)
                     finally:
-                        # Liberamos el cerrojo y restauramos el cursor al final de todo
                         self.procesando_url = False
                         wx.EndBusyCursor()
 

--- a/controller/main_controller.py
+++ b/controller/main_controller.py
@@ -159,16 +159,19 @@ class MainController:
                 wx.BeginBusyCursor()
 
                 def handle_tiktok_result(result):
-                    if isinstance(result, Exception):
-                        wx.MessageBox(_("Error al simplificar URL de TikTok: {}").format(result), _("Error"), wx.ICON_ERROR)
-                    elif result:
-                        self._continuar_abriendo_chat(result)
-                    else:
-                        wx.MessageBox(_("No se pudo obtener la URL real de TikTok."), _("Error"), wx.ICON_ERROR)
-                    
-                    # Liberamos el cerrojo y restauramos el cursor al final de todo
-                    self.procesando_url = False
-                    wx.EndBusyCursor()
+                    # El finally garantiza soltar el cerrojo aunque algo falle aquí:
+                    # si quedara en True, ya no podría abrirse ningún chat más.
+                    try:
+                        if isinstance(result, Exception):
+                            wx.MessageBox(_("Error al simplificar URL de TikTok: {}").format(result), _("Error"), wx.ICON_ERROR)
+                        elif result:
+                            self._continuar_abriendo_chat(result)
+                        else:
+                            wx.MessageBox(_("No se pudo obtener la URL real de TikTok."), _("Error"), wx.ICON_ERROR)
+                    finally:
+                        # Liberamos el cerrojo y restauramos el cursor al final de todo
+                        self.procesando_url = False
+                        wx.EndBusyCursor()
 
                 network.execute(canonical_scraper.get_simplified_tiktok_live_url(url), callback=handle_tiktok_result)
             else:

--- a/servicios/sala.py
+++ b/servicios/sala.py
@@ -60,7 +60,7 @@ class ServicioSala:
                         if data_store.config['eventos'][1]:
                             wx.CallAfter(self.chat_controller.agregar_mensaje_miembro, message['author'] +': ' +message['message'])
                             if data_store.config['reader'] and data_store.config['unread'][1]: wx.CallAfter(reader.leer_mensaje, message['author'] +': ' +message['message'])
-                            if data_store.config['sonidos'] and data_store.config['listasonidos'][2]: wx.CallAfter(player.play, rutasonidos[2])
+                            if data_store.config['sonidos'] and data_store.config['listasonidos'][1]: wx.CallAfter(player.play, rutasonidos[1])
                 else:
                     if data_store.config['categorias'][0] and hasattr(self.chat_controller.ui, 'list_box_general'):
                         if data_store.config['eventos'][0]:

--- a/update/update.py
+++ b/update/update.py
@@ -70,8 +70,14 @@ async def async_check_update(endpoint, current_version):
         if not traducir:
             available_description = available_update.get('description', None)
         else:
-            translator = TranslatorWrapper()
-            available_description = translator.translate(available_update.get('description', None), target=languageHandler.curLang[:2])
+            # Si la traducción falla, la comprobación en sí fue bien: usar la
+            # descripción original en vez de convertirla en un falso error.
+            try:
+                translator = TranslatorWrapper()
+                available_description = translator.translate(available_update.get('description', None), target=languageHandler.curLang[:2])
+            except Exception:
+                logger.exception("No se pudo traducir la descripción de la actualización")
+                available_description = available_update.get('description', None)
             
         update_url = available_update['downloads'][arch_key]
         
@@ -82,8 +88,11 @@ async def async_check_update(endpoint, current_version):
             'donations': donations
         }
     except Exception as e:
-        logger.error(f"Error checking for updates: {e}")
-        return None
+        # Devolver la excepción, NO None: None significa "sin actualización", y la
+        # comprobación manual respondería "tienes la última versión" sin red.
+        # handle_check_result (updater.py) ya distingue una Exception y avisa.
+        logger.exception("Error al comprobar actualizaciones")
+        return e
 
 def download_update(update_url, update_destination, client, progress_callback=None, chunk_size=128*1024):
     total_downloaded = 0

--- a/update/update.py
+++ b/update/update.py
@@ -67,17 +67,15 @@ async def async_check_update(endpoint, current_version):
             logger.debug("No update available or not for this architecture")
             return None
             
-        if not traducir:
-            available_description = available_update.get('description', None)
-        else:
-            # Si la traducción falla, la comprobación en sí fue bien: usar la
+        available_description = available_update.get('description', None)
+        if traducir:
+            # Si la traducción falla, la comprobación en sí fue bien: dejar la
             # descripción original en vez de convertirla en un falso error.
             try:
                 translator = TranslatorWrapper()
-                available_description = translator.translate(available_update.get('description', None), target=languageHandler.curLang[:2])
+                available_description = translator.translate(available_description, target=languageHandler.curLang[:2])
             except Exception:
                 logger.exception("No se pudo traducir la descripción de la actualización")
-                available_description = available_update.get('description', None)
             
         update_url = available_update['downloads'][arch_key]
         


### PR DESCRIPTION
## Qué corrige

**1. "Buscar actualizaciones" mentía sin conexión (`update/update.py`)**
`async_check_update` tragaba cualquier excepción y devolvía `None`, el mismo valor que "no hay actualización". Resultado: sin red, la comprobación manual respondía "Al parecer tienes la última versión del programa". La rama de error de `handle_check_result` (`updater.py`) ya existía con su mensaje traducido, pero era inalcanzable. Ahora la función devuelve la excepción (mismo contrato que ya usa el motor de `utils/network.py` para entregar errores al callback) y la comprobación manual muestra el error real; el arranque sigue silencioso como siempre. Además, si lo único que falla es la *traducción* de la descripción (googletrans caído), se usa la descripción original en vez de perder la actualización entera.

**2. El privado de la sala de juegos sonaba como "nuevo miembro" (`servicios/sala.py`)**
El bloque de mensajes privados usaba `rutasonidos[2]`/`listasonidos[2]` (sonido y casilla de "se conecta un miembro"), mientras que las otras cinco plataformas gatean los mensajes de miembros con `listasonidos[1]` → `rutasonidos[1]` (youtube, twich, kick, tiktok, YouTubeRealDataTime). Ahora la sala hace lo mismo: suena `chatmiembro.mp3` y lo controla la casilla correcta de los ajustes ("Sonido cuando habla un miembro").

**3. Un fallo en el callback de TikTok podía bloquear la app entera (`controller/main_controller.py`)**
`handle_tiktok_result` soltaba el cerrojo `procesando_url` y el cursor de espera al final del callback; si algo lanzaba una excepción antes (por ejemplo dentro de `_continuar_abriendo_chat`), el cerrojo quedaba en `True` para siempre y ya no podía abrirse ningún chat de ninguna plataforma hasta reiniciar, sin ningún mensaje. Ahora un `try/finally` garantiza soltarlo siempre. Revisé los demás callbacks de `network.execute` (idiomas, token de Discord, updater): este era el único sitio con el patrón invertido.

## Pruebas

- Banco dedicado (26/26) que ejecuta las funciones reales con dobles de wx/red/sonido: panne de red y HTTP 500 → se devuelve la excepción; traductor caído → descripción original; los tres tipos de retorno (dict/None/Exception) manejados por `handle_check_result` en el orden correcto; privado de la sala → índice 1 gateado por la casilla 1, público → índice 0 intacto; cerrojo liberado aunque el callback explote, cursor equilibrado y la app capaz de abrir chats después. Sobre el código sin corregir fallan exactamente las 8 comprobaciones clave de los tres fallos.
- `py_compile` sobre los tres archivos; ninguna cadena visible nueva (cero impacto en los catálogos de idiomas).
- Revisión de código en 8 ángulos independientes + verificación adversarial: sin hallazgos de corrección; dos retoques de estilo aplicados en el segundo commit.

## Nota

Si la red se queda *colgada* sin responder (en vez de fallar), la comprobación puede esperar indefinidamente: es el tema ya conocido del `timeout=None` del cliente httpx central, que dejo para el futuro sprint del updater — fuera del alcance de esta PR.

🤖 Generated with Claude Code