### PR TITLE
Repaso del motor de voz: cinco fallos confirmados tras revisar el PR #99

### DIFF
--- a/TTS/sherpa_handler.py
+++ b/TTS/sherpa_handler.py
@@ -144,7 +144,7 @@ def _entrada_metadata(clave, valor):
     interno = b"\x0a" + _varint(len(k)) + k + b"\x12" + _varint(len(v)) + v
     return b"\x72" + _varint(len(interno)) + interno
 
-def preparar_voz_piper(json_path):
+def preparar_voz_piper(json_path, forzar=False):
     """Prepara (una sola vez) una voz del catálogo rhasspy para sherpa-onnx.
 
     Los paquetes oficiales k2-fsa traen de fábrica dos piezas que las voces
@@ -159,11 +159,16 @@ def preparar_voz_piper(json_path):
     El tokens.txt se escribe EL ÚLTIMO porque hace de marcador de «voz ya
     preparada»: si algo se interrumpe a medias, el próximo intento rehace
     todo (los metadatos repetidos con el mismo valor son inofensivos).
+
+    forzar=True rehace la preparación aunque el marcador esté: hay que usarlo
+    siempre que se sustituya el .onnx de una carpeta ya preparada (reinstalar
+    una voz), porque el tokens.txt viejo sobrevive al fichero nuevo y este se
+    quedaría sin metadatos — y un .onnx sin metadatos aborta el puente entero.
     """
     try:
         carpeta = os.path.dirname(json_path)
         marcador = os.path.join(carpeta, "tokens.txt")
-        if os.path.isfile(marcador):
+        if os.path.isfile(marcador) and not forzar:
             return True
         with open(json_path, encoding="utf-8") as f:
             cfg = json.load(f)
@@ -307,13 +312,21 @@ class sherpaSpeak:
             pass
 
     def _cleanup_own_orphans(self):
-        """Mata instancias del puente que hayan quedado huérfanas."""
+        """Mata instancias del puente que hayan quedado huérfanas, pero SOLO las
+        lanzadas desde nuestra propia carpeta de binarios: comparar únicamente
+        el nombre del ejecutable mataba también el puente de otra instalación
+        de VeTube abierta a la vez (portable, copia de desarrollo), que se
+        quedaba muda sin volver a levantarlo."""
         try:
             import psutil
-            for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
+            ruta_propia = os.path.normcase(os.path.abspath(EXE_PUENTE))
+            for proc in psutil.process_iter(['pid', 'name', 'exe']):
                 try:
                     nombre = (proc.info.get('name') or '').lower()
-                    if nombre == NOMBRE_EXE_PUENTE:
+                    if nombre != NOMBRE_EXE_PUENTE:
+                        continue
+                    ruta = proc.info.get('exe')
+                    if ruta and os.path.normcase(ruta) == ruta_propia:
                         proc.kill()
                 except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
@@ -363,18 +376,32 @@ class sherpaSpeak:
             model_path = self.current_voice_path
         if not model_path: return
 
-        # Si el archivo ONNX no existe en la ruta dada (debido a diferencias de nombres de carpeta),
-        # lo buscamos dinámicamente dentro de subcarpetas de voices/
-        # (las rutas kokoro «carpeta?sid=..» no existen como fichero y pasan tal cual)
-        if not os.path.exists(model_path):
+        # Las rutas de Kokoro («carpeta?sid=..&lang=..») no son ficheros: pasan
+        # tal cual, sin buscarlas en el disco.
+        es_ruta_kokoro = "?" in model_path
+
+        # Si el .onnx no está en la ruta dada (nombres de carpeta que no
+        # coinciden), lo buscamos dentro de voices/. Solo en las carpetas
+        # «voice-*»: en voices/ vive también el paquete de Kokoro, y sus
+        # ficheros (model.onnx, tokens.txt) no son voces de Piper.
+        if not es_ruta_kokoro and not os.path.exists(model_path):
             import glob
             filename = os.path.basename(model_path)
-            coincidencias = glob.glob(os.path.join("voices", "*", filename))
+            coincidencias = glob.glob(os.path.join("voices", "voice-*", filename))
             if coincidencias:
                 model_path = coincidencias[0]
 
         if model_path.endswith(".onnx"):
             json_path = model_path + ".json"
+            if not os.path.exists(json_path):
+                # Voz colocada a mano: su configuración puede llamarse de otro
+                # modo (config.json, <nombre>.json). Sin este repli se enviaría
+                # el .onnx crudo, que se salta la preparación de abajo y llega
+                # al puente sin tokens.txt.
+                import glob
+                otros = [j for j in glob.glob(os.path.join(os.path.dirname(model_path), "*.json"))
+                         if "+RT" not in os.path.basename(j)]
+                json_path = otros[0] if otros else json_path
             if os.path.exists(json_path):
                 model_path = json_path
 
@@ -384,9 +411,18 @@ class sherpaSpeak:
         # el proceso del puente entero, no solo la carga.
         if model_path.endswith(".json") and not preparar_voz_piper(model_path):
             print(f"Voz no preparada para sherpa, no se carga: {model_path}")
+            # Soltar la voz anterior: si no, el puente seguiría hablando con
+            # ella (puede ser la del otro motor) mientras Ajustes muestra la
+            # que se acaba de elegir.
+            self.unload_model()
             return
 
         self.current_voice_path = model_path
+        # Invalidar la voz anterior antes de pedir la nueva: mientras el puente
+        # responde, un mensaje del chat encontraría el identificador viejo, no
+        # esperaría (ver _speak_task_inner) y se leería con la voz que el
+        # usuario acaba de abandonar, incluso la del otro motor.
+        self.voice_id = None
         asyncio.run_coroutine_threadsafe(self._load_voice_task(model_path), self.loop)
 
     async def _load_voice_task(self, model_path):

--- a/controller/kokoro_downloader_controller.py
+++ b/controller/kokoro_downloader_controller.py
@@ -29,6 +29,10 @@ class KokoroDownloaderController:
         self.descargando = True
         self.fase_instalacion = False
         self.cancelacion_pedida = False
+        # Aquí y no dentro de instalar_modelo: la corrutina no arranca hasta que
+        # el bucle de red le hace sitio, y un Escape pulsado en ese hueco se
+        # habría borrado al empezar ella.
+        self.manager.cancelado = False
         self.view.btn_descargar.Disable()
         # El foco estaba en el botón recién deshabilitado: sin esto queda en el
         # limbo y un usuario de lector de pantalla ya no sabe dónde está.

--- a/servicios/base_downloader.py
+++ b/servicios/base_downloader.py
@@ -26,6 +26,7 @@ class BaseDownloader:
 
                 total = int(response.headers.get('content-length', 0))
                 descargado = 0
+                ultimo_avance = -1
 
                 with open(dest_path, 'wb') as f:
                     async for chunk in response.aiter_bytes():
@@ -34,9 +35,14 @@ class BaseDownloader:
                         f.write(chunk)
                         descargado += len(chunk)
                         if progress_callback and total > 0:
-                            # Calculamos el progreso porcentual
+                            # Solo cuando el porcentaje cambia de verdad: cada
+                            # aviso cruza al hilo de la interfaz (wx.CallAfter)
+                            # y un fichero grande da miles de bloques para cien
+                            # valores distintos.
                             progreso_actual = int(descargado / total * 100)
-                            progress_callback(progreso_actual)
+                            if progreso_actual != ultimo_avance:
+                                ultimo_avance = progreso_actual
+                                progress_callback(progreso_actual)
 
             return {'success': True, 'data': dest_path}
         except Exception as e:

--- a/servicios/kokoro_manager.py
+++ b/servicios/kokoro_manager.py
@@ -51,8 +51,12 @@ class KokoroManager(BaseDownloader):
 
     async def instalar_modelo(self, progress_callback=None):
         """Descarga el paquete, lo extrae en un temporal y lo mueve a voices/.
-        Devuelve {'success': bool, 'cancelado': bool, 'data': detalle}."""
-        self.cancelado = False
+        Devuelve {'success': bool, 'cancelado': bool, 'data': detalle}.
+
+        La bandera de cancelación NO se reinicia aquí: esta corrutina empieza a
+        correr cuando el bucle de red le hace sitio, y quien cancele entre medias
+        (el bucle también atiende los chats) se habría quedado sin efecto. La
+        reinicia quien lanza la descarga, antes de encolarla."""
         temp_dir = tempfile.mkdtemp(prefix="vetube_kokoro_")
         tar_path = os.path.join(temp_dir, CARPETA_MODELO + ".tar.bz2")
         try:

--- a/servicios/piper_manager.py
+++ b/servicios/piper_manager.py
@@ -180,15 +180,25 @@ class PiperManager(BaseDownloader):
                 except OSError:
                     pass
             return next(r for r in results if not r['success'])
-        for parte, final in partes:
-            os.replace(parte, final)
+        # Renombrado y preparación van dentro del try: un fallo aquí (fichero
+        # retenido por el antivirus, voz que se está reinstalando) reventaba la
+        # corrutina y dejaba el descargador congelado sin decir nada.
+        try:
+            for parte, final in partes:
+                os.replace(parte, final)
 
-        # El motor sherpa necesita el tokens.txt y los metadatos del .onnx:
-        # se preparan una vez desde el .json recién descargado (equivalente a
-        # lo que traen de fábrica los paquetes oficiales k2-fsa).
-        from TTS.sherpa_handler import preparar_voz_piper
-        for rel_path in archivos.keys():
-            if rel_path.endswith(".onnx.json"):
-                preparar_voz_piper(os.path.join(dest_dir, os.path.basename(rel_path)))
+            # El motor sherpa necesita el tokens.txt y los metadatos del .onnx:
+            # se preparan desde el .json recién descargado (equivalente a lo que
+            # traen de fábrica los paquetes oficiales k2-fsa). forzar=True
+            # porque al reinstalar una voz el tokens.txt anterior sigue ahí y el
+            # .onnx nuevo se quedaría sin metadatos.
+            from TTS.sherpa_handler import preparar_voz_piper
+            for rel_path in archivos.keys():
+                if rel_path.endswith(".onnx.json"):
+                    preparar_voz_piper(os.path.join(dest_dir, os.path.basename(rel_path)),
+                                       forzar=True)
+        except Exception as e:
+            traceback.print_exc()
+            return {'success': False, 'data': str(e)}
 
         return {'success': True, 'data': dest_dir}

--- a/utils/app_utilitys.py
+++ b/utils/app_utilitys.py
@@ -43,6 +43,12 @@ def proponer_migracion_rt(parent):
     la voz de Piper (arranque y Aceptar de los Ajustes). Devuelve True si la
     lista de voces pudo cambiar."""
     from servicios.piper_manager import voces_rt_instaladas, limpiar_ficheros_rt
+    # config['voz'] es una POSICIÓN en la lista, y la migración la hace crecer
+    # (una carpeta RT pura pasa a contar como voz instalada): nos quedamos con
+    # el NOMBRE de la voz activa para recolocarla después. Comprobar solo el
+    # rango no sirve — un índice desplazado sigue estando dentro.
+    voz_activa = (lista_voces_piper[config['voz']]
+                  if 0 <= config['voz'] < len(lista_voces_piper) else None)
     puras, mixtas = voces_rt_instaladas()
     # Carpetas que ya tienen el modelo estándar: los restos RT solo ocupan sitio.
     for clave in mixtas:
@@ -60,7 +66,9 @@ def proponer_migracion_rt(parent):
     lista_voces_piper.clear()
     nuevas = piper_list_voices()
     lista_voces_piper.extend(nuevas if nuevas else [_("No hay voces instaladas")])
-    if not (0 <= config['voz'] < len(lista_voces_piper)):
+    if voz_activa in lista_voces_piper:
+        config['voz'] = lista_voces_piper.index(voz_activa)
+    elif not (0 <= config['voz'] < len(lista_voces_piper)):
         config['voz'] = 0
     return True
 def _cargar_voz_piper_actual():


### PR DESCRIPTION
Los dos fallos que encontraste leyendo el PR #99 me hicieron pensar que habría más de la misma familia, así que le he pasado al código una revisión sistemática, ángulo por ángulo, con verificación de cada hallazgo. Salieron cinco fallos confirmados y cuatro plausibles, todos de lo mismo: estado compartido entre los dos motores e índices de voz. Aquí van corregidos, con su banco.

Nada de esto ha llegado a los usuarios: está solo en canary, no hay versión publicada con el motor nuevo.

## El más serio

Reinstalar una voz de Piper que ya se tenía la dejaba **sin metadatos en el .onnx**. El tokens.txt hace de marcador de «voz ya preparada» y sobrevive al fichero que se sustituye, así que la preparación se saltaba y el modelo nuevo llegaba al puente pelado. Un .onnx sin metadatos **aborta el proceso del puente entero**: VeTube se queda muda con los dos motores hasta reiniciar, y otra vez en cada arranque. El descargador no marca las voces ya instaladas, así que basta con volver a bajar una por costumbre.

## Los otros

- **La migración RT podía cambiarte de voz.** config['voz'] es una posición, y la migración hace crecer la lista: una voz inglesa migrada por delante de la española en uso, y el chat pasaba a leerse en inglés sin avisar. Solo se comprobaba el rango, y un índice desplazado sigue dentro del rango. Ahora se recoloca por nombre.
- **Si la preparación de una voz fallaba**, load_model se volvía sin soltar la anterior: seguía hablando la voz del otro motor mientras Ajustes mostraba la elegida — justo lo que arreglamos ayer, por otro camino.
- **load_model no invalidaba voice_id** antes de pedir la voz nueva, así que un mensaje que llegara durante la carga se leía con la voz que acababas de abandonar.
- **_cleanup_own_orphans mataba el puente de otra instalación** de VeTube abierta a la vez (portable, copia de desarrollo): comparaba solo el nombre del ejecutable, cuando el handler de sonata comparaba la ruta. La víctima se quedaba muda sin volver a levantarlo.
- **Volvió el repli del .json con otro nombre** en la carpeta de la voz, que hacía sonata: sin él, una voz colocada a mano se enviaba en crudo y el puente la rechazaba en silencio.
- **El descargador podía congelarse sin decir nada**: el renombrado del .part quedaba fuera del try, y un fallo ahí mataba la corrutina sin reactivar los botones ni anunciar nada.
- **Una cancelación pedida muy pronto se perdía**: la bandera se reiniciaba al arrancar la corrutina, no al pedir la descarga.
- **La barra avisaba en cada bloque** recibido, mil veces para cien valores, al mismo hilo que va leyendo el chat.

## Comprobado

Banco nuevo de 28 comprobaciones para estos arreglos (incluida la reinstalación de una voz, que reproduce el fallo principal), más los bancos que ya había: filtro de idioma 43/43, detección de voces 9/9, motores mezclados 7/7, cancelación OK, bascule Piper 14/15 — el que falta es un caso del propio banco, que copiaba una voz RT real como material de partida y esa voz ya está migrada.

## De paso

Dos avisos que la revisión dejó anotados y que no toco aquí para no mezclar: el mismo bloque de «formatear devicenames y fijar el dispositivo» está copiado en siete sitios, y el instalador de Kokoro reimplementa download_file en vez de reutilizar el de BaseDownloader. Si quieres los junto en un PR de limpieza aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
