### PR TITLE
Limpieza: un solo sitio para fijar el dispositivo y una sola implementación de download_file

### DIFF
--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -384,7 +384,6 @@ class AjustesController:
             self.dialog.lista_dispositivos.SetFocus()
             return
         valor = self.dialog.lista_dispositivos.GetSelection() + 1
-        valor_str = self.dialog.lista_dispositivos.GetStringSelection()
         config['dispositivo'] = valor
         player.setdevice(config["dispositivo"])
         player.play(f"sounds/{config['directorio']}/cambiardispositivo.mp3")
@@ -392,10 +391,9 @@ class AjustesController:
             hay_voz = config['sistemaTTS'] == "kokoro" or (
                 lista_voces_piper and lista_voces_piper[0] != _("No hay voces instaladas"))
             if hay_voz:
-                # Reutilizamos los nombres que ya tiene el player formateados para Sonata
-                nombres = player.devicenames
-                dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres)]
-                reader._lector.set_device(reader._lector.find_device_id(valor_str, known_devices=dispositivos_formateados))
+                # La lista del diálogo se construye con player.devicenames, así que
+                # el nombre elegido y el que saca config['dispositivo'] son el mismo.
+                app_utilitys.fijar_dispositivo_lector()
             reader.leer_auto(_("Hablaré a través de este dispositivo."))
 
     def reproducirPrueva(self, event):
@@ -442,19 +440,12 @@ class AjustesController:
             from TTS.list_voices import obtener_ruta_voz
             # Simplemente cargamos el nuevo modelo en el lector existente
             reader._lector.load_model(obtener_ruta_voz(lista_voces_piper[config['voz']]))
-            # El dispositivo se mantiene o se actualiza si es necesario, usando dispositivos conocidos
-            nombres = player.devicenames
-            dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres)]
-            salida_piper = reader._lector.find_device_id(nombres[config["dispositivo"]-1], known_devices=dispositivos_formateados)
-            reader._lector.set_device(salida_piper)
+            app_utilitys.fijar_dispositivo_lector()
         elif config['sistemaTTS'] == "kokoro":
             config_kokoro = kokoro_voice_config(config['voz'])
             if config_kokoro is not None:
                 reader._lector.load_model(config_kokoro)
-                nombres = player.devicenames
-                dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres)]
-                salida_kokoro = reader._lector.find_device_id(nombres[config["dispositivo"]-1], known_devices=dispositivos_formateados)
-                reader._lector.set_device(salida_kokoro)
+                app_utilitys.fijar_dispositivo_lector()
             elif event is not None:
                 # Solo cuando el usuario elige una voz a mano: esta función
                 # también se llama sola (filtro de idioma, Cancelar), y ahí el
@@ -656,10 +647,7 @@ class AjustesController:
                     config['sistemaTTS'] == "piper" and lista_voces_piper
                     and lista_voces_piper[0] != _("No hay voces instaladas")))
                 if hay_voz_local:
-                    nombres = player.devicenames
-                    dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres)]
-                    valor_str = nombres[config['dispositivo'] - 1]
-                    reader._lector.set_device(reader._lector.find_device_id(valor_str, known_devices=dispositivos_formateados))
+                    app_utilitys.fijar_dispositivo_lector()
             except Exception:
                 # Puede fallar si el dispositivo guardado desapareció mientras Ajustes estaba
                 # abierto (auriculares desconectados, etc. — mismo caso que setup.py al arrancar).

--- a/controller/menus/main_menu_controller.py
+++ b/controller/menus/main_menu_controller.py
@@ -9,7 +9,7 @@ from ui.dialog_response import response
 from globals import data_store
 from globals.resources import carpeta_voces,codes,codigos_traduccion
 from controller.editor_controller import EditorController
-from setup import network, reader, player
+from setup import network, reader
 from exchange import codes as currency_codes
 from servicios.language_updater import GestorRepositorios
 from ui.update_languages_dialog import UpdateLanguagesDialog
@@ -184,10 +184,7 @@ class MainMenuController:
 
         reader.set_sapi(data_store.config['sapi'])
         if data_store.config['sistemaTTS'] in ("piper", "kokoro"):
-            nombres = player.devicenames
-            dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres)]
-            salida_actual = reader._lector.find_device_id(nombres[data_store.config["dispositivo"]-1], known_devices=dispositivos_formateados)
-            reader._lector.set_device(salida_actual)
+            app_utilitys.fijar_dispositivo_lector()
             if data_store.config['sistemaTTS'] == "piper":
                 app_utilitys.configurar_piper(self.frame, carpeta_voces)
         if cf.choice_moneditas.GetStringSelection()!='Por defecto':

--- a/run_main_window.py
+++ b/run_main_window.py
@@ -8,7 +8,7 @@ from globals.resources import carpeta_voces,lista_voces_piper
 from controller.main_controller import MainController
 from update import updater,update
 from TTS.lector import detect_onnx_models
-from utils.app_utilitys import configurar_piper, limpiar_motor_antiguo
+from utils.app_utilitys import configurar_piper, limpiar_motor_antiguo, fijar_dispositivo_lector
 if sys.platform == "win32": asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 def run_app():
@@ -33,11 +33,7 @@ def run_app():
             modelo = kokoro_voice_config(config['voz'])
         if modelo is not None:
             setup.reader._lector.load_model(modelo)
-            nombres_dispositivos = setup.player.devicenames
-            dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres_dispositivos)]
-            nombre_actual = nombres_dispositivos[config["dispositivo"]-1]
-            salida_actual = setup.reader._lector.find_device_id(nombre_actual, known_devices=dispositivos_formateados)
-            setup.reader._lector.set_device(salida_actual)
+            fijar_dispositivo_lector()
         elif config['sistemaTTS'] == "kokoro":
             # Modelo Kokoro no disponible: avisar con la voz secundaria en lugar
             # de arrancar con la voz principal muda (revisión de accesibilidad).

--- a/servicios/base_downloader.py
+++ b/servicios/base_downloader.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-import traceback
+from logging import getLogger
 from setup import network
+
+logger = getLogger(__name__)
 
 class BaseDownloader:
     """Clase base para gestionar descargas asíncronas de archivos."""
@@ -9,22 +11,35 @@ class BaseDownloader:
     def __init__(self, base_dir="."):
         self.base_dir = base_dir
 
-    async def download_file(self, url, dest_path, progress_callback=None, cancel_check=None):
+    async def download_file(self, url, dest_path, progress_callback=None, cancel_check=None,
+                            timeout=None, total_estimado=0, tope_progreso=100):
         """
         Descarga un archivo desde una URL a una ruta local.
         Reporta el progreso a través de un callback. Si se pasa cancel_check,
         se consulta en cada bloque recibido y la descarga se corta en cuanto
-        devuelve True (mismo patrón que el instalador de Kokoro).
+        devuelve True.
+
+        Los tres últimos parámetros son para descargas con necesidades propias:
+        timeout, un límite de httpx solo para esta descarga; total_estimado, el
+        tamaño conocido de antemano por si el servidor no informa del
+        content-length; tope_progreso, el valor máximo que recibe el callback
+        cuando la descarga solo ocupa un tramo de la barra y el resto se
+        reserva para lo que venga después.
         """
         try:
             # Asegurar que el directorio de destino existe
             os.makedirs(os.path.dirname(dest_path), exist_ok=True)
 
-            async with network.client.stream("GET", url, follow_redirects=True) as response:
+            # Sin timeout propio se deja el del cliente central: pasarle None a
+            # httpx no significa "el de siempre", significa "sin límite".
+            opciones = {'timeout': timeout} if timeout is not None else {}
+            async with network.client.stream("GET", url, follow_redirects=True, **opciones) as response:
                 if response.status_code != 200:
-                    return {'success': False, 'data': f"HTTP {response.status_code} al descargar {url}"}
+                    logger.error("HTTP %s al descargar %s", response.status_code, url)
+                    return {'success': False, 'status_code': response.status_code,
+                            'data': f"HTTP {response.status_code} al descargar {url}"}
 
-                total = int(response.headers.get('content-length', 0))
+                total = int(response.headers.get('content-length', 0)) or total_estimado
                 descargado = 0
                 ultimo_avance = -1
 
@@ -39,14 +54,14 @@ class BaseDownloader:
                             # aviso cruza al hilo de la interfaz (wx.CallAfter)
                             # y un fichero grande da miles de bloques para cien
                             # valores distintos.
-                            progreso_actual = int(descargado / total * 100)
+                            progreso_actual = min(tope_progreso, int(descargado / total * tope_progreso))
                             if progreso_actual != ultimo_avance:
                                 ultimo_avance = progreso_actual
                                 progress_callback(progreso_actual)
 
             return {'success': True, 'data': dest_path}
         except Exception as e:
-            traceback.print_exc()
+            logger.error("Fallo al descargar %s", url, exc_info=True)
             return {'success': False, 'data': str(e)}
 
     def ensure_dir(self, directory):

--- a/servicios/kokoro_manager.py
+++ b/servicios/kokoro_manager.py
@@ -7,7 +7,6 @@ import shutil
 import httpx
 from logging import getLogger
 from .base_downloader import BaseDownloader
-from setup import network
 
 logger = getLogger(__name__)
 
@@ -79,36 +78,28 @@ class KokoroManager(BaseDownloader):
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     async def _descargar(self, url, dest_path, progress_callback):
-        """Como BaseDownloader.download_file, pero cancelable y con el progreso
-        mapeado al tramo 0-90 (el 90-100 es de la extracción)."""
-        try:
+        """La descarga en sí la hace BaseDownloader.download_file: aquí solo se
+        le pasan las particularidades de este paquete y se traduce su resultado
+        al formato con 'cancelado' que espera el resto del instalador."""
+        res = await self.download_file(
+            url, dest_path,
+            progress_callback=progress_callback,
+            cancel_check=lambda: self.cancelado,
             # El cliente central no tiene timeout: aquí ponemos uno de lectura
             # para que una conexión congelada termine en error visible en vez
             # de dejar la descarga (y al usuario) esperando para siempre.
-            timeout = httpx.Timeout(60.0, connect=15.0)
-            async with network.client.stream("GET", url, follow_redirects=True, timeout=timeout) as response:
-                if response.status_code != 200:
-                    logger.error("HTTP %s al descargar %s", response.status_code, url)
-                    return {'success': False, 'cancelado': False,
-                            'data': _("el servidor de descargas respondió con el error HTTP %d.") % response.status_code}
-
-                total = int(response.headers.get('content-length', 0)) or TAMANO_DESCARGA
-                descargado = 0
-                ultimo_avance = -1
-                with open(dest_path, 'wb') as f:
-                    async for chunk in response.aiter_bytes():
-                        if self.cancelado:
-                            return {'success': False, 'cancelado': True, 'data': ''}
-                        f.write(chunk)
-                        descargado += len(chunk)
-                        avance = min(90, int(descargado / total * 90))
-                        if progress_callback and avance != ultimo_avance:
-                            ultimo_avance = avance
-                            progress_callback(avance)
-            return {'success': True, 'cancelado': False, 'data': dest_path}
-        except Exception as e:
-            logger.error("Fallo al descargar el modelo Kokoro", exc_info=True)
-            return {'success': False, 'cancelado': False, 'data': str(e)}
+            timeout=httpx.Timeout(60.0, connect=15.0),
+            total_estimado=TAMANO_DESCARGA,
+            tope_progreso=90)
+        if res.get('cancelado'):
+            # Sin detalle: al cancelar no se le enseña ningún mensaje al usuario.
+            return {'success': False, 'cancelado': True, 'data': ''}
+        if res.get('status_code'):
+            # Mensaje propio: el de la clase base lleva la URL cruda dentro y
+            # este se le enseña al usuario en un cuadro de diálogo.
+            return {'success': False, 'cancelado': False,
+                    'data': _("el servidor de descargas respondió con el error HTTP %d.") % res['status_code']}
+        return {'success': res['success'], 'cancelado': False, 'data': res['data']}
 
     def _extraer_e_instalar(self, tar_path, temp_dir, progress_callback):
         """Corre en un hilo aparte. Extrae en el temporal, verifica y mueve la

--- a/utils/app_utilitys.py
+++ b/utils/app_utilitys.py
@@ -21,6 +21,16 @@ def restart_program():
         os.remove(pidpath)
     os.execv(sys.executable, args)
 def porcentaje_a_escala(porcentaje): return 1.25 + porcentaje * 0.125
+def fijar_dispositivo_lector():
+    """Fija en el puente sherpa la salida de audio que marca config['dispositivo']
+    (1 = el primero de la lista, igual que para el player).
+
+    Los nombres que ya tiene el player valen de known_devices: así no hay que
+    volver a abrir el subsistema de audio solo para enumerar los dispositivos."""
+    nombres_dispositivos = player.devicenames
+    dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres_dispositivos)]
+    nombre_actual = nombres_dispositivos[config["dispositivo"]-1]
+    reader._lector.set_device(reader._lector.find_device_id(nombre_actual, known_devices=dispositivos_formateados))
 def limpiar_motor_antiguo():
     """Borra la carpeta del antiguo servidor sonata (64/sonata) si quedó de
     una instalación anterior. El actualizador copia la versión nueva POR
@@ -78,11 +88,7 @@ def _cargar_voz_piper_actual():
     if not model_path:
         return
     reader._lector = reader._lector.piperSpeak(model_path)
-    nombres_dispositivos = player.devicenames
-    dispositivos_formateados = [{'name': n, 'id': i} for i, n in enumerate(nombres_dispositivos)]
-    nombre_actual = nombres_dispositivos[config["dispositivo"]-1]
-    salida_actual = reader._lector.find_device_id(nombre_actual, known_devices=dispositivos_formateados)
-    reader._lector.set_device(salida_actual)
+    fijar_dispositivo_lector()
 def configurar_piper(parent, carpeta_voces):
     migrado = proponer_migracion_rt(parent)
     onnx_models = detect_onnx_models(carpeta_voces)


### PR DESCRIPTION
Los dos avisos que dejaste anotados tras la revisión del #99, en un PR aparte para no mezclarlos con nada. **Sin ningún cambio de comportamiento buscado**: es limpieza pura.

## 1. El bloque del dispositivo, de siete copias a una

El mismo bloque de «formatear devicenames y fijar el dispositivo» estaba copiado en siete sitios: el arranque (`run_main_window`), el Aceptar del menú principal, tres caminos de Ajustes (cambiar dispositivo, cambiar voz con Piper, cambiar voz con Kokoro), la carga de la voz de Piper y el revert de Cancelar. Ahora vive una sola vez, en `app_utilitys.fijar_dispositivo_lector()`.

Los seis primeros eran idénticos. El séptimo, `establecer_dispositivo`, pasaba el nombre elegido en el `wx.Choice` en lugar del que sale de `config['dispositivo']` — pero son el mismo valor: la lista del diálogo se construye con `player.devicenames` (`ui/ajustes/sonidos.py`) y `config['dispositivo']` se acaba de escribir con esa misma selección, dos líneas más arriba. Por eso el helper no necesita parámetro ni variantes, y los siete sitios quedan con la misma línea.

He puesto el helper en `utils/app_utilitys.py` porque los tres ficheros que lo llaman desde fuera ya importaban ese módulo: ni un import nuevo, ni riesgo de ciclo en el arranque.

## 2. El instalador de Kokoro ya no reimplementa `download_file`

`KokoroManager._descargar` tenía su propio `client.stream`, su bucle de bloques, su escritura a disco, su progreso y su cancelación. Ahora delega en `BaseDownloader.download_file` y solo aporta lo suyo, mediante tres parámetros opcionales nuevos:

- `timeout`: un límite propio para esta descarga, porque el cliente central no tiene ninguno y una conexión congelada dejaba al usuario esperando para siempre.
- `total_estimado`: el tamaño conocido del paquete, por si el servidor no manda `content-length` (sin esto, cero avance en la barra durante 350 MB).
- `tope_progreso`: la descarga ocupa el 0-90 de la barra, el 90-100 es la extracción.

Los tres traen por defecto el comportamiento anterior, así que `piper_manager` y `language_updater` quedan **estrictamente intactos** (siguen llamando en posicional, y el `.onnx` sigue siendo el único que informa del progreso en Piper).

Si prefieres que `tope_progreso` no viva en la clase base por ser una decisión de barra de progreso, se puede mover al llamante envolviendo el callback; lo dejé aquí porque así el filtro de «solo cuando el porcentaje cambia de verdad» sigue funcionando a la resolución real de la barra, y los valores que llegan al diálogo son exactamente los de antes. Dime y lo cambio.

## Tres cosas que salieron al hacerlo

- `base_downloader` mandaba sus errores a stdout con `traceback.print_exc()`, mientras el resto de `servicios/` ya usa el logger desde el #82. Al delegar, los fallos de Kokoro habrían dejado de llegar al fichero de registro: ahora la clase base usa el logger, y con eso no se pierde nada.
- El progreso queda acotado con `min()`: un `content-length` más corto que el cuerpo real ya no puede empujar la barra por encima de su tope.
- El resultado de un error HTTP añade `status_code`. Es lo que permite a Kokoro seguir enseñando su mensaje traducido en el diálogo, en vez del de la clase base, que lleva la URL cruda dentro (un lector de pantalla la leería entera).

## Comprobaciones

Un banco de pruebas compara el código nuevo con el viejo **llamada por llamada**, con el player y el puente simulados: los mismos `find_device_id`/`set_device` con los mismos argumentos para las siete posiciones de la lista de dispositivos, y los mismos porcentajes de la barra de Kokoro (incluidos los redondeos), la misma cancelación, el mismo mensaje HTTP traducido y el mismo respaldo sin `content-length`. 34 comprobaciones, todas en verde.

**No se toca ninguna cadena visible**: ningún `msgid` cambia, así que no hay nada que hacer en los seis catálogos ni en `translates/`.

Probado con NVDA: arranque, prueba de voz, cambio de dispositivo (con su sonido y su «Hablaré a través de este dispositivo»), cambio de voz, revert con Escape, Aceptar, y la bascula Piper ↔ Kokoro. Todo igual que antes.

---

Aprovecho para dejarte dos cosas que vi de paso y que **no toco aquí**, por si quieres que las mire en otro PR:

1. ~~Me temo que elegir el dispositivo de salida nunca llega a aplicarse a la voz de Piper/Kokoro.~~ **Me equivoqué, olvida este punto.** Lo escribí leyendo el código: `Channel.set_device` está documentado como 1-based (0 = «no sound») mientras que `sherpa_handler.get_devices()` construye los `id` en base 0. Pero Enzo lo probó justo después en un equipo con **varias salidas de audio**, y tanto Piper como Kokoro cambian de salida perfectamente. El enrutado real no depende de esa llamada: el stream se crea sobre el dispositivo BASS activo, que es el que acaba de fijar `SoundPlayer`, y el `set_device` desfasado falla en silencio dentro de su `except: pass`, sin efecto audible. Lo dejo escrito por si algún día se quita ese `except`, pero **no hay nada que arreglar**.
2. `helpers/sound_helper.py` es una copia de `players/sound_helper.py` que ya no importa nadie, y su comprobación de rango dice `device > 0 or device < len(...)` donde la viva dice `and device <=`. Si es código muerto, se puede borrar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

