### PR TITLE
ci: add GitHub Actions workflow for automated builds and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Build and Release
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*'
 
@@ -39,15 +41,14 @@ jobs:
 
       - name: Compress with 7-Zip (maximum compression)
         run: |
-          $version = "${{ github.ref_name }}"
-          7z a -t7z -mx=9 "vetube-$version-portable.7z" "build/vetube/*"
+          7z a -t7z -mx=9 "vetube.7z" "build/vetube/*"
         shell: pwsh
 
       - name: Upload portable artifact
         uses: actions/upload-artifact@v4
         with:
           name: portable-build
-          path: vetube-*-portable.7z
+          path: vetube.7z
           retention-days: 1
 
   build-msi:
@@ -73,11 +74,17 @@ jobs:
         run: uv run cxfreeze bdist_msi
         shell: pwsh
 
+      - name: Rename MSI to vetube.setup
+        run: |
+          $msiFile = Get-ChildItem -Path "dist" -Filter "*.msi" | Select-Object -First 1
+          Rename-Item -Path $msiFile.FullName -NewName "vetube.setup"
+        shell: pwsh
+
       - name: Upload MSI artifact
         uses: actions/upload-artifact@v4
         with:
           name: msi-build
-          path: dist/*.msi
+          path: dist/vetube.setup
           retention-days: 1
 
   release:
@@ -108,8 +115,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/*.7z
-            dist/*.msi
+            dist/vetube.7z
+            dist/vetube.setup
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,15 @@ jobs:
 
       - name: Compress with 7-Zip (maximum compression)
         run: |
-          7z a -t7z -mx=9 "vetube.7z" "build/vetube/*"
+          $version = "${{ github.ref_name }}"
+          7z a -t7z -mx=9 "vetube-$version.7z" "build/vetube/*"
         shell: pwsh
 
       - name: Upload portable artifact
         uses: actions/upload-artifact@v4
         with:
           name: portable-build
-          path: vetube.7z
+          path: vetube-*.7z
           retention-days: 1
 
   build-msi:
@@ -76,15 +77,16 @@ jobs:
 
       - name: Rename MSI to vetube.setup
         run: |
+          $version = "${{ github.ref_name }}"
           $msiFile = Get-ChildItem -Path "dist" -Filter "*.msi" | Select-Object -First 1
-          Rename-Item -Path $msiFile.FullName -NewName "vetube.setup"
+          Rename-Item -Path $msiFile.FullName -NewName "vetube-$version.setup"
         shell: pwsh
 
       - name: Upload MSI artifact
         uses: actions/upload-artifact@v4
         with:
           name: msi-build
-          path: dist/vetube.setup
+          path: dist/vetube-*.setup
           retention-days: 1
 
   release:
@@ -115,8 +117,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/vetube.7z
-            dist/vetube.setup
+            dist/vetube-*.7z
+            dist/vetube-*.setup
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-portable:
+    name: Build Portable Version
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Build portable version
+        run: uv run cxfreeze build
+
+      - name: Rename build folder
+        run: |
+          $buildPath = Get-ChildItem -Path "build" -Directory | Select-Object -First 1
+          Rename-Item -Path $buildPath.FullName -NewName "vetube"
+        shell: pwsh
+
+      - name: Compress with 7-Zip (maximum compression)
+        run: |
+          $version = "${{ github.ref_name }}"
+          7z a -t7z -mx=9 "vetube-$version-portable.7z" "build/vetube/*"
+        shell: pwsh
+
+      - name: Upload portable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: portable-build
+          path: vetube-*-portable.7z
+          retention-days: 1
+
+  build-msi:
+    name: Build MSI Installer
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Build MSI installer
+        run: uv run cxfreeze bdist_msi
+        shell: pwsh
+
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-build
+          path: dist/*.msi
+          retention-days: 1
+
+  release:
+    name: Create Release
+    needs: [build-portable, build-msi]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download portable artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: portable-build
+          path: dist/
+
+      - name: Download MSI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: msi-build
+          path: dist/
+
+      - name: List release assets
+        run: ls -la dist/
+        shell: bash
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.7z
+            dist/*.msi
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add automated CI/CD workflow using Astral UV for building and releasing VeTube.

## Changes

- Add \elease.yml\ workflow triggered on version tags (v*) from master branch
- Build portable version with cx_Freeze and compress with 7-Zip (maximum compression)
- Build MSI installer with cx_Freeze bdist_msi
- Automatically create GitHub release with both assets

## Workflow Details

The workflow runs on \windows-latest\ runners with two parallel jobs:

1. **build-portable**: Builds portable version with \uv run cxfreeze build\, renames folder to \etube\, compresses with 7-Zip at maximum compression (\-mx=9\)
2. **build-msi**: Builds MSI installer with \uv run cxfreeze bdist_msi\

After both jobs complete, the \elease\ job:
- Downloads both artifacts
- Creates a GitHub release with automatic release notes
- Uploads both files as release assets

## Release Assets

- \etube-{version}.7z\ - Portable version (7-Zip archive)
- \etube-{version}.setup\ - MSI installer

## Usage

To trigger a release:
\\\ash
git tag v3.95
git push origin v3.95
\\\

The workflow will automatically build and publish the release.

## Related

Closes #104