### PR TITLE
feat(ci): automatic prerelease detection for beta/rc/alpha tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,19 @@ jobs:
         run: ls -la dist/
         shell: bash
 
+      - name: Detect prerelease
+        id: detect
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" =~ -beta|-rc|-alpha ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "Tag $TAG detected as prerelease"
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "Tag $TAG detected as stable release"
+          fi
+        shell: bash
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -122,7 +135,7 @@ jobs:
             dist/vetube-*.7z
             dist/vetube-*.msi
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.detect.outputs.prerelease }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds automatic prerelease detection to the release workflow based on tag naming patterns.

## Changes

- Detects prerelease tags containing -beta, -rc, or -alpha
- Sets prerelease: true automatically for these tags
- Stable releases (e.g., 3.95) remain as regular releases
- All releases generate the same artifacts (portable + MSI)

## Behavior

**Stable release:**
- Tag: 3.95
- Prerelease: alse
- Winget: ✅ triggers
- Artifacts: ✅ generated

**Prerelease:**
- Tag: 3.95-beta.1, 3.95-rc.1, 3.95-alpha.1
- Prerelease: 	rue
- Winget: ❌ skipped (already configured)
- Artifacts: ✅ generated

## Testing

After merge, create a test tag like 3.95-rc1 to verify the prerelease flow works correctly.