### PR TITLE
fix(updater): critical fixes for v3.95 release

### DIFF
--- a/update/update.py
+++ b/update/update.py
@@ -25,7 +25,9 @@ def perform_update(update_url, donations=True, password=None, progress_callback=
     # solo vería que "no pasa nada". La registramos para poder diagnosticar el caso.
     try:
         base_path = tempfile.mkdtemp()
-        download_path = os.path.join(base_path, 'update.zip')
+        # Determinar extensión del archivo según la URL
+        url_ext = os.path.splitext(update_url)[1].lower() or '.7z'
+        download_path = os.path.join(base_path, f'update{url_ext}')
         update_path = os.path.join(base_path, 'update')
         logger.info("Iniciando actualización desde %s", update_url)
 
@@ -114,10 +116,24 @@ def download_update(update_url, update_destination, client, progress_callback=No
 
 def extract_update(update_archive, destination, password=None):
     """Given an update archive, extracts it. Returns the directory to which it has been extracted"""
-    with contextlib.closing(zipfile.ZipFile(update_archive)) as archive:
+    archive_ext = os.path.splitext(update_archive)[1].lower()
+    
+    if archive_ext == '.7z':
+        # Usar 7z.exe para archivos .7z
+        import subprocess
+        cmd = ['7z', 'x', update_archive, f'-o{destination}', '-y']
         if password:
-            archive.setpassword(password)
-        archive.extractall(path=destination)
+            cmd.extend([f'-p{password}'])
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"Error extracting 7z archive: {result.stderr}")
+    else:
+        # Usar zipfile para archivos .zip
+        with contextlib.closing(zipfile.ZipFile(update_archive)) as archive:
+            if password:
+                archive.setpassword(password)
+            archive.extractall(path=destination)
+    
     logger.debug("Update extracted")
     return destination
 

--- a/update/updater.py
+++ b/update/updater.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 from . import update
+from .version import VERSION
 from builtins import str
 import logging
 from .wxUpdater import *
 from setup import network
 logger = logging.getLogger("updater")
-
-# Versión global del programa
-VERSION = "3.94"
 
 # Cerrojo global para evitar múltiples búsquedas simultáneas
 buscando = False

--- a/update/version.py
+++ b/update/version.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Versión actual de VeTube
+# Este archivo se actualiza manualmente con cada release
+VERSION = "3.95"

--- a/updater.json
+++ b/updater.json
@@ -1,7 +1,7 @@
 {
-    "current_version": "3.94",
-    "description": "actualizar para leer en vivos de tiktok.",
+    "current_version": "3.95",
+    "description": "Nueva versión con mejoras de rendimiento y correcciones de errores.",
     "downloads": {
-        "Windows64": "https://github.com/metalalchemist/VeTube/releases/latest/download/VeTube-x64.zip"
+        "Windows64": "https://github.com/metalalchemist/VeTube/releases/latest/download/vetube-v3.95.7z"
     }
 }


### PR DESCRIPTION
## Summary

Fixes critical issues preventing the auto-updater from working with v3.95 release.

## Changes

### 1. Version Management
- **Created update/version.py**: Centralized VERSION constant for easier maintenance
- **Updated updater.py**: Import VERSION from version module instead of hardcoded value

### 2. Download URL & Format
- **Updated updater.json**: 
  - Version: 3.94 → 3.95
  - URL: VeTube-x64.zip → etube-v3.95.7z (matches new CI output format)
  - Description: Updated to generic message

### 3. Archive Extraction
- **Added 7z support**: extract_update() now detects .7z files and uses 7z.exe command
- **Fallback preserved**: .zip files still use zipfile module
- **Dynamic filename**: Download filename now uses correct extension from URL

### 4. Bootstrap Compatibility
- **Verified**: ootstrap.exe already handles cx_Freeze _internal/ structure (see ootstrap_fix.py lines 52-56)
- **Included in build**: pyproject.toml includes ootstrap.exe in include_files

## Testing

After merge:
1. Build v3.95 release with new CI
2. Verify etube-v3.95.7z contains ootstrap.exe
3. Test auto-update from v3.94 → v3.95

## Related

- Closes #106 (winget integration - separate PR)
- Related to PR #109 (winget publisher rewrite)
- Related to PR #110 (prerelease support)