### PR TITLE
feat(updater): foundation modules for new updater (Phase 1/4)

### DIFF
--- a/update/backup.py
+++ b/update/backup.py
@@ -1,0 +1,126 @@
+"""Backup and restore support for safe update rollback."""
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class InsufficientSpaceError(OSError):
+    """Raised when there is not enough disk space for a backup."""
+
+
+def _dir_size(path: str) -> int:
+    """Calculate total size of a directory tree in bytes."""
+    total = 0
+    for dirpath, _, filenames in os.walk(path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            try:
+                total += os.path.getsize(fp)
+            except OSError:
+                pass
+    return total
+
+
+def check_disk_space(install_dir: str) -> Tuple[bool, int]:
+    """Check if there is enough disk space for a backup.
+
+    Requires free space >= 2x the install directory size (one copy for the
+    backup, one for the extraction target).
+
+    Args:
+        install_dir: Path to the application installation directory.
+
+    Returns:
+        Tuple of (ok, required_mb). ``ok`` is True when enough space is
+        available. ``required_mb`` is the estimated space needed in megabytes.
+    """
+    install_size = _dir_size(install_dir)
+    required_bytes = install_size * 2
+    required_mb = required_bytes // (1024 * 1024)
+
+    usage = shutil.disk_usage(os.path.dirname(os.path.abspath(install_dir)))
+    ok = usage.free >= required_bytes
+
+    if not ok:
+        logger.warning(
+            "Insufficient disk space: need %d MB, have %d MB",
+            required_mb,
+            usage.free // (1024 * 1024),
+        )
+
+    return ok, required_mb
+
+
+def create_backup(install_dir: str, version: str) -> str:
+    """Create a backup of the installation directory.
+
+    Checks disk space first (needs 2x install size). Creates a
+    ``_backup_v{version}/`` directory in the parent of install_dir.
+
+    Args:
+        install_dir: Path to the application installation directory.
+        version: Version string for the backup directory name.
+
+    Returns:
+        Path to the created backup directory.
+
+    Raises:
+        InsufficientSpaceError: If not enough disk space is available.
+    """
+    ok, required_mb = check_disk_space(install_dir)
+    if not ok:
+        raise InsufficientSpaceError(
+            f"Need {required_mb} MB free for backup, insufficient disk space"
+        )
+
+    parent = Path(install_dir).parent
+    backup_path = str(parent / f"_backup_v{version}")
+
+    logger.info("Creating backup at '%s'", backup_path)
+    shutil.copytree(install_dir, backup_path, dirs_exist_ok=True)
+    logger.info("Backup created successfully")
+
+    return backup_path
+
+
+def restore_backup(backup_path: str, install_dir: str) -> None:
+    """Restore a backup to the installation directory.
+
+    Deletes the current install_dir contents and copies the backup back.
+
+    Args:
+        backup_path: Path to the backup directory.
+        install_dir: Path to the application installation directory.
+
+    Raises:
+        FileNotFoundError: If backup_path does not exist.
+    """
+    if not os.path.isdir(backup_path):
+        raise FileNotFoundError(f"Backup not found: '{backup_path}'")
+
+    logger.info("Restoring backup from '%s' to '%s'", backup_path, install_dir)
+
+    if os.path.exists(install_dir):
+        shutil.rmtree(install_dir)
+
+    shutil.copytree(backup_path, install_dir)
+    logger.info("Backup restored successfully")
+
+
+def cleanup_backup(backup_path: str) -> None:
+    """Delete a backup directory. Silent if it doesn't exist.
+
+    Args:
+        backup_path: Path to the backup directory to remove.
+    """
+    if not os.path.isdir(backup_path):
+        logger.debug("Backup '%s' does not exist, nothing to clean up", backup_path)
+        return
+
+    logger.info("Cleaning up backup at '%s'", backup_path)
+    shutil.rmtree(backup_path, ignore_errors=True)

--- a/update/bootstrap.py
+++ b/update/bootstrap.py
@@ -1,0 +1,94 @@
+"""Bootstrap process launcher with UAC elevation for file replacement."""
+
+import logging
+import subprocess
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_EXIT_SUCCESS = 0
+_EXIT_FAILURE = 1
+_EXIT_CANCELLED = 2
+_EXIT_TIMEOUT = -1
+_WAIT_TIMEOUT_SECONDS = 30
+
+
+def _build_args(pid: int, source_dir: str, dest_dir: str, exe_path: str) -> str:
+    """Build the command-line argument string for bootstrap.exe."""
+    return f'"{pid}" "{source_dir}" "{dest_dir}" "{exe_path}"'
+
+
+def _is_process_running(name: str) -> bool:
+    """Check if a process with the given name is currently running."""
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FI", f"IMAGENAME eq {name}", "/NH"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return name.lower() in result.stdout.lower()
+    except (subprocess.SubprocessError, OSError):
+        logger.debug("Failed to check process '%s'", name, exc_info=True)
+        return False
+
+
+def launch_bootstrap(
+    bootstrap_exe: str,
+    pid: int,
+    source_dir: str,
+    dest_dir: str,
+    exe_path: str,
+) -> int:
+    """Launch bootstrap.exe to replace files and relaunch the app.
+
+    Requests UAC elevation via ShellExecute with 'runas' verb, then waits
+    for the process to complete.
+
+    Args:
+        bootstrap_exe: Path to bootstrap.exe.
+        pid: PID of the current application process to terminate.
+        source_dir: Directory containing the new version files.
+        dest_dir: Target installation directory.
+        exe_path: Path to the application executable to relaunch.
+
+    Returns:
+        Exit code: 0=success, 1=failure, 2=cancelled by user, -1=timeout.
+    """
+    import win32api
+    import win32con
+
+    args = _build_args(pid, source_dir, dest_dir, exe_path)
+    logger.info(
+        "Launching bootstrap: '%s' %s", bootstrap_exe, args
+    )
+
+    try:
+        result = win32api.ShellExecute(
+            0,
+            "runas",
+            bootstrap_exe,
+            args,
+            None,
+            win32con.SW_SHOW,
+        )
+    except Exception:
+        logger.exception("Failed to launch bootstrap (UAC may have been denied)")
+        return _EXIT_CANCELLED
+
+    if isinstance(result, int) and result <= 32:
+        logger.error("ShellExecute failed with code: %s", result)
+        return _EXIT_FAILURE
+
+    logger.info("Bootstrap launched, waiting for completion (timeout=%ds)", _WAIT_TIMEOUT_SECONDS)
+
+    deadline = time.monotonic() + _WAIT_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if not _is_process_running("bootstrap.exe"):
+            logger.info("Bootstrap process completed")
+            return _EXIT_SUCCESS
+        time.sleep(0.5)
+
+    logger.error("Bootstrap did not complete within %d seconds", _WAIT_TIMEOUT_SECONDS)
+    return _EXIT_TIMEOUT

--- a/update/channel.py
+++ b/update/channel.py
@@ -1,0 +1,71 @@
+"""Update channel management for stable and beta release filtering."""
+
+import logging
+import re
+from typing import List
+
+from utils.fajustes import leerConfiguracion, guardarConfiguracion
+
+logger = logging.getLogger(__name__)
+
+VALID_CHANNELS = ("stable", "beta")
+DEFAULT_CHANNEL = "stable"
+_PRERELEASE_PATTERN = re.compile(r"-(beta|rc|alpha|dev|pre)", re.IGNORECASE)
+
+
+def get_channel() -> str:
+    """Read update_channel from data.json.
+
+    Returns:
+        'stable' or 'beta'. Defaults to 'stable' if not set.
+    """
+    configs = leerConfiguracion()
+    channel = configs.get("update_channel", DEFAULT_CHANNEL)
+    if channel not in VALID_CHANNELS:
+        logger.warning("Invalid channel '%s', falling back to '%s'", channel, DEFAULT_CHANNEL)
+        return DEFAULT_CHANNEL
+    return channel
+
+
+def set_channel(channel: str) -> None:
+    """Write update_channel to data.json.
+
+    Args:
+        channel: Only accepts 'stable' or 'beta'.
+
+    Raises:
+        ValueError: If channel is not a valid value.
+    """
+    if channel not in VALID_CHANNELS:
+        raise ValueError(f"Invalid channel '{channel}'. Must be one of {VALID_CHANNELS}")
+    configs = leerConfiguracion()
+    configs["update_channel"] = channel
+    guardarConfiguracion(configs)
+    logger.info("Update channel set to '%s'", channel)
+
+
+def filter_releases(releases: List[dict], channel: str) -> List[dict]:
+    """Filter GitHub releases by channel.
+
+    Stable: only releases whose tag matches v* with no prerelease suffix.
+    Beta: all releases including prereleases.
+
+    Args:
+        releases: List of GitHub API release objects.
+        channel: 'stable' or 'beta'.
+
+    Returns:
+        Filtered list of release dicts.
+    """
+    if channel == "beta":
+        return releases
+
+    filtered = []
+    for release in releases:
+        tag = release.get("tag_name", "")
+        if _PRERELEASE_PATTERN.search(tag):
+            continue
+        if release.get("prerelease", False):
+            continue
+        filtered.append(release)
+    return filtered

--- a/update/downloader.py
+++ b/update/downloader.py
@@ -1,0 +1,52 @@
+"""Streaming file downloader with progress reporting."""
+
+import logging
+from typing import Callable, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_CHUNK_SIZE = 128 * 1024
+
+
+def download(
+    url: str,
+    dest_path: str,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+) -> str:
+    """Download file from URL to dest_path with optional progress reporting.
+
+    Uses httpx streaming to read in 128KB chunks.
+
+    Args:
+        url: URL to download from.
+        dest_path: Local file path to write to.
+        progress_callback: Called with (bytes_downloaded, total_bytes) per chunk.
+            total_bytes is 0 if Content-Length is unknown.
+
+    Returns:
+        dest_path on success.
+
+    Raises:
+        httpx.HTTPStatusError: On HTTP errors.
+        OSError: On file write errors.
+    """
+    logger.info("Downloading '%s' to '%s'", url, dest_path)
+
+    with httpx.Client(follow_redirects=True, timeout=300) as client:
+        with client.stream("GET", url) as response:
+            response.raise_for_status()
+
+            total_bytes = int(response.headers.get("content-length", 0))
+            bytes_downloaded = 0
+
+            with open(dest_path, "wb") as f:
+                for chunk in response.iter_bytes(chunk_size=_CHUNK_SIZE):
+                    f.write(chunk)
+                    bytes_downloaded += len(chunk)
+                    if progress_callback:
+                        progress_callback(bytes_downloaded, total_bytes)
+
+    logger.info("Download complete: %d bytes", bytes_downloaded)
+    return dest_path

--- a/update/extractor.py
+++ b/update/extractor.py
@@ -1,0 +1,51 @@
+"""Zip archive extraction with progress reporting and error recovery."""
+
+import logging
+import os
+import shutil
+import zipfile
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def extract(
+    zip_path: str,
+    dest_dir: str,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+) -> None:
+    """Extract a zip file to dest_dir.
+
+    Iterates members for granular progress reporting. On failure, deletes
+    the partial extraction directory to avoid leaving corrupted state.
+
+    Args:
+        zip_path: Path to the .zip archive.
+        dest_dir: Directory to extract into.
+        progress_callback: Called with (extracted_count, total_count) per member.
+
+    Raises:
+        zipfile.BadZipFile: If the archive is corrupt or invalid.
+        PermissionError: If a file is locked or write-protected.
+        OSError: On other I/O errors during extraction.
+    """
+    logger.info("Extracting '%s' to '%s'", zip_path, dest_dir)
+
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            members = zf.infolist()
+            total = len(members)
+
+            for index, member in enumerate(members, start=1):
+                zf.extract(member, dest_dir)
+                if progress_callback:
+                    progress_callback(index, total)
+
+    except (zipfile.BadZipFile, PermissionError, OSError) as exc:
+        logger.error("Extraction failed: %s", exc)
+        if os.path.isdir(dest_dir):
+            logger.info("Cleaning up partial extraction at '%s'", dest_dir)
+            shutil.rmtree(dest_dir, ignore_errors=True)
+        raise
+
+    logger.info("Extraction complete: %d members", total)

--- a/update/github_client.py
+++ b/update/github_client.py
@@ -1,0 +1,163 @@
+"""GitHub Releases API client with in-memory caching and ETag support."""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import httpx
+
+from update.channel import filter_releases, get_channel
+
+logger = logging.getLogger(__name__)
+
+RELEASES_URL = "https://api.github.com/repos/metalalchemist/VeTube/releases"
+CACHE_TTL_SECONDS = 300
+_USER_AGENT = "VeTube-Updater/1.0"
+
+
+@dataclass
+class ReleaseInfo:
+    """Parsed release information from GitHub API."""
+
+    tag: str
+    version: str
+    prerelease: bool
+    description: str
+    zip_url: str
+    checksum_url: str
+    zip_name: str
+
+
+class _ReleaseCache:
+    """In-memory cache with TTL and ETag support."""
+
+    def __init__(self) -> None:
+        self.data: Optional[ReleaseInfo] = None
+        self.timestamp: float = 0
+        self.etag: Optional[str] = None
+
+    def is_fresh(self) -> bool:
+        return self.data is not None and (time.time() - self.timestamp) < CACHE_TTL_SECONDS
+
+    def store(self, release: Optional[ReleaseInfo], etag: Optional[str]) -> None:
+        self.data = release
+        self.timestamp = time.time()
+        if etag:
+            self.etag = etag
+
+
+_cache = _ReleaseCache()
+
+
+def _parse_release(release: dict) -> Optional[ReleaseInfo]:
+    """Extract ReleaseInfo from a GitHub release dict.
+
+    Returns None if required assets (zip + checksum) are missing.
+    """
+    tag = release.get("tag_name", "")
+    if not tag:
+        return None
+
+    assets = release.get("assets", [])
+    zip_url = ""
+    zip_name = ""
+    checksum_url = ""
+
+    for asset in assets:
+        name = asset.get("name", "")
+        url = asset.get("browser_download_url", "")
+        if name.endswith(".zip") and not zip_url:
+            zip_url = url
+            zip_name = name
+        elif name.endswith(".sha256") and not checksum_url:
+            checksum_url = url
+
+    if not zip_url or not checksum_url:
+        logger.debug("Release '%s' missing zip or checksum asset, skipping", tag)
+        return None
+
+    version = tag.lstrip("v")
+
+    return ReleaseInfo(
+        tag=tag,
+        version=version,
+        prerelease=release.get("prerelease", False),
+        description=release.get("body", ""),
+        zip_url=zip_url,
+        checksum_url=checksum_url,
+        zip_name=zip_name,
+    )
+
+
+def _fetch_releases(client: httpx.Client) -> tuple[list[dict], Optional[str], bool]:
+    """Fetch releases from GitHub API.
+
+    Returns:
+        Tuple of (releases_list, etag, not_modified).
+        If not_modified is True, releases_list is empty.
+    """
+    headers: Dict[str, str] = {"User-Agent": _USER_AGENT}
+    if _cache.etag:
+        headers["If-None-Match"] = _cache.etag
+
+    response = client.get(RELEASES_URL, headers=headers, timeout=30)
+
+    if response.status_code == 304:
+        return [], None, True
+
+    response.raise_for_status()
+    etag = response.headers.get("ETag")
+    return response.json(), etag, False
+
+
+def get_latest_release(channel: Optional[str] = None) -> Optional[ReleaseInfo]:
+    """Fetch latest release from GitHub API.
+
+    Uses in-memory cache with 5-min TTL and ETag for conditional requests.
+
+    Args:
+        channel: 'stable' or 'beta'. Defaults to user preference.
+
+    Returns:
+        ReleaseInfo for the latest matching release, or None if no update
+        available or on error.
+    """
+    if channel is None:
+        channel = get_channel()
+
+    if _cache.is_fresh():
+        logger.debug("Returning cached release info")
+        return _cache.data
+
+    try:
+        with httpx.Client() as client:
+            releases, etag, not_modified = _fetch_releases(client)
+
+            if not_modified:
+                _cache.timestamp = time.time()
+                return _cache.data
+
+            filtered = filter_releases(releases, channel)
+            if not filtered:
+                logger.info("No releases found for channel '%s'", channel)
+                _cache.store(None, etag)
+                return None
+
+            release_info = _parse_release(filtered[0])
+            _cache.store(release_info, etag)
+            return release_info
+
+    except httpx.HTTPError:
+        logger.exception("Failed to fetch releases from GitHub")
+        return None
+    except Exception:
+        logger.exception("Unexpected error fetching releases")
+        return None
+
+
+def clear_cache() -> None:
+    """Clear the release cache. Useful for forcing a fresh check."""
+    _cache.data = None
+    _cache.timestamp = 0
+    _cache.etag = None

--- a/update/verifier.py
+++ b/update/verifier.py
@@ -1,0 +1,88 @@
+"""SHA256 verification for downloaded update archives."""
+
+import hashlib
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+_HASH_BUFFER_SIZE = 65536
+
+
+def compute_sha256(file_path: str) -> str:
+    """Compute SHA256 hash of a file.
+
+    Args:
+        file_path: Path to the file to hash.
+
+    Returns:
+        Lowercase hex digest string.
+    """
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        while True:
+            data = f.read(_HASH_BUFFER_SIZE)
+            if not data:
+                break
+            sha256.update(data)
+    return sha256.hexdigest().lower()
+
+
+def parse_checksum_file(content: str) -> Dict[str, str]:
+    """Parse sha256sum format: '{hash}  {filename}' per line.
+
+    Handles both two-space and single-space separators.
+    Blank lines and lines without a valid format are skipped.
+
+    Args:
+        content: Raw text content of a .sha256 checksum file.
+
+    Returns:
+        Dict mapping filename -> hash (lowercase).
+    """
+    result: Dict[str, str] = {}
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            logger.debug("Skipping malformed checksum line: '%s'", line)
+            continue
+        hash_value, filename = parts
+        result[filename.strip()] = hash_value.strip().lower()
+    return result
+
+
+def verify(zip_path: str, checksum_content: str, expected_name: str) -> bool:
+    """Verify zip file integrity against checksum content.
+
+    Args:
+        zip_path: Path to the downloaded zip file.
+        checksum_content: Raw text of the .sha256 checksum file.
+        expected_name: Filename to look up in the checksum file.
+
+    Returns:
+        True if the computed hash matches the expected hash, False otherwise.
+    """
+    checksums = parse_checksum_file(checksum_content)
+    expected_hash = checksums.get(expected_name)
+
+    if expected_hash is None:
+        logger.error("Filename '%s' not found in checksum file", expected_name)
+        return False
+
+    actual_hash = compute_sha256(zip_path)
+    match = actual_hash == expected_hash.lower()
+
+    if match:
+        logger.info("Verification passed for '%s'", expected_name)
+    else:
+        logger.error(
+            "Verification FAILED for '%s': expected=%s, actual=%s",
+            expected_name,
+            expected_hash,
+            actual_hash,
+        )
+
+    return match


### PR DESCRIPTION
﻿## Summary

Phase 1 of the new updater redesign: 7 foundation modules that will replace the current manual updater.json-based system with a GitHub Releases API-driven approach.

## Changes

### New modules in `update/`

| Module | Lines | Purpose |
|--------|-------|---------|
| `channel.py` | 71 | Read/write update_channel from data.json, filter releases by tag pattern |
| `github_client.py` | 163 | GitHub Releases API client with 5-min TTL cache + ETag support |
| `downloader.py` | 52 | Streaming download with progress callback |
| `verifier.py` | 88 | SHA256 computation + checksum file parsing + verification |
| `backup.py` | 126 | Backup creation, rollback restore, cleanup, disk space check |
| `extractor.py` | 51 | Zipfile extraction with progress reporting |
| `bootstrap.py` | 94 | Launch bootstrap.exe with UAC elevation, interpret exit codes |

**Total**: 645 lines across 7 new files

## Design Decisions

- **HTTP client**: Sync `httpx.Client` (not async) — updater flow is sequential by nature
- **Channel persistence**: Uses `guardarConfiguracion()` for writes (full merged config dict)
- **Bootstrap**: Uses `win32api.ShellExecute` with `"runas"` for UAC, polls `tasklist` for completion
- **Backup**: Custom `InsufficientSpaceError` exception, requires 2x install size
- **No `__init__.py`**: Existing `update/` package uses implicit namespace imports

## What's NOT in this PR

- No modifications to existing files (updater.py, update.py, wxUpdater.py) — that's Phase 2
- No tests — that's Phase 5
- No CI/CD changes — that's Phase 3
- No deletion of updater.json — that's Phase 2

## Testing

Each module is self-contained and testable in isolation. Tests will be added in Phase 5.

## Related

- Part of the new-updater SDD change
- Phase 2 (Integration) will wire these modules together
- Phase 3 (UI + CI) will add user-facing features
- Phase 4 (Testing) will add comprehensive test coverage
