### PR TITLE
La casilla «Usar voz sapi» vuelve a mandar sobre el chat, y solo sobre el chat

### DIFF
--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from globals.data_store import config
+from globals.data_store import config, motor_de_interfaz
 from globals.resources import rutasonidos,lista_voces,lista_voces_piper,recargar_rutasonidos
 from setup import player,reader
 from utils import app_utilitys, languageHandler
@@ -30,12 +30,12 @@ class AccesibleInstalador(Accesible):
     el rol que anuncia el lector de pantalla debe decir la verdad en ambos
     casos, así que se decide en el momento en que se consulta."""
     def GetRole(self, childId):
-        if config['sistemaTTS'] == "kokoro":
+        if motor_de_interfaz() == "kokoro":
             return (wx.ACC_OK, wx.ROLE_SYSTEM_PUSHBUTTON)
         return super().GetRole(childId)
 
     def GetDefaultAction(self, childId):
-        if config['sistemaTTS'] == "kokoro":
+        if motor_de_interfaz() == "kokoro":
             # Sin acción especial: que wx anuncie la de un botón normal
             return (wx.ACC_NOT_IMPLEMENTED, "")
         return super().GetDefaultAction(childId)
@@ -78,18 +78,20 @@ class AjustesController:
         # a mano para que el lector de pantalla siempre anuncie una.
         self._seleccionar_voz_activa()
 
-        # Sincronización inicial de parámetros
-        if config['sistemaTTS'] in ("piper", "kokoro"):
+        # Sincronización inicial de parámetros. Con la casilla marcada quien
+        # lee el programa es el lector de pantalla: no hay motor que ajustar.
+        motor = motor_de_interfaz()
+        if motor in ("piper", "kokoro"):
             reader._lector.set_volume(config['volume'])
             reader._lector.set_pitch(config['tono'])
             # Aplicamos la velocidad inicial usando la escala correcta
             reader._lector.set_rate(app_utilitys.porcentaje_a_escala(config['speed']))
-        elif config['sistemaTTS'] == "edge":
+        elif motor == "edge":
             reader._lector.set_volume(config['volume'])
             reader._lector.set_pitch(config['tono'])
             # Edge usa la velocidad nativa (-10 a 10) sin reescalar
             reader._lector.set_rate(config['speed'])
-        elif config['sistemaTTS'] == "onecore":
+        elif motor == "onecore":
             reader._lector.set_volume(config['volume'])
             reader._lector.set_rate(config['speed'])
             # Aplicar el tono guardado para OneCore (posición 0-4, por defecto 0.6 = 0.6)
@@ -171,6 +173,11 @@ class AjustesController:
         mover ninguna voz de sitio: cada estado lee y escribe SU clave (ver
         _voz_editada).
         """
+        # Quien lee el programa cambia con la casilla: marcada vuelve el lector
+        # de pantalla, desmarcada vuelve el motor elegido. set_tts pasa por
+        # configurar_tts, que de paso cierra el puente del motor que se aparta
+        # en vez de dejarlo en memoria con su modelo cargado (Kokoro, 350 MB).
+        reader.set_tts(motor_de_interfaz())
         self.dialog.seleccionar_TTS.Enable(not config['sapi'])
         self.actualizar_visibilidad_instalador()
         # actualizar_filtro_idioma recoloca el filtro en el idioma del programa.
@@ -240,7 +247,7 @@ class AjustesController:
             # recupera la del que entra, así cada uno vuelve donde lo dejaste.
             self._recordar_voz(motor_anterior)
             self._recuperar_voz(config['sistemaTTS'])
-        reader.set_tts(config['sistemaTTS'])
+        reader.set_tts(motor_de_interfaz())
         if config['sistemaTTS'] in ("piper", "kokoro", "edge"):
             # Cada motor arranca de cero, con la salida de audio por defecto.
             # Antes Piper y Kokoro compartían un único puente que ya la tenía
@@ -610,15 +617,16 @@ class AjustesController:
         config['dispositivo'] = valor
         player.setdevice(config["dispositivo"])
         player.play(f"sounds/{config['directorio']}/cambiardispositivo.mp3")
-        if config['sistemaTTS'] in ("piper", "kokoro"):
-            hay_voz = config['sistemaTTS'] == "kokoro" or (
+        motor = motor_de_interfaz()
+        if motor in ("piper", "kokoro"):
+            hay_voz = motor == "kokoro" or (
                 lista_voces_piper and lista_voces_piper[0] != _("No hay voces instaladas"))
             if hay_voz:
                 # La lista del diálogo se construye con player.devicenames, así que
                 # el nombre elegido y el que saca config['dispositivo'] son el mismo.
                 app_utilitys.fijar_dispositivo_lector()
             reader.leer_auto(_("Hablaré a través de este dispositivo."))
-        elif config['sistemaTTS'] == "edge":
+        elif motor == "edge":
             app_utilitys.fijar_dispositivo_lector()
             reader.leer_auto(_("Hablaré a través de este dispositivo."))
 
@@ -743,7 +751,14 @@ class AjustesController:
             config['tono'] = value
     def cambiarVelocidad(self, event):
         value = self.dialog.slider_3.GetValue() - 10
+        config['speed'] = value
         reader._leer.set_rate(value)
+        if config['sapi']:
+            # La velocidad es la de la voz SAPI que lee el chat; el motor está
+            # apartado y el lector de pantalla lleva la suya. Además la rama de
+            # piper indexa lista_voces_piper con la selección de la lista, que
+            # ahora son las voces SAPI: entrar ahí cogería una voz cualquiera.
+            return
         if config['sistemaTTS'] == "piper":
             voz_actual = lista_voces_piper[self.dialog.choice_2.GetSelection()]
             if voz_actual != _("No hay voces instaladas"):
@@ -755,7 +770,6 @@ class AjustesController:
             reader._lector.set_rate(value)
         else:
             reader._lector.set_rate(value)
-        config['speed'] = value
     def instalar_paquete_voz(self, event):
         if config['sistemaTTS'] == "kokoro":
             KokoroDownloaderController(self.dialog).show()

--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -159,14 +159,28 @@ class AjustesController:
 
     def checar_sapi(self, event):
         config['sapi'] = event.IsChecked()
+        self._recargar_panel_de_voz()
+
+    def _recargar_panel_de_voz(self):
+        """Deja el panel al día de quien lee el chat: lista de voces, filtro de
+        idioma, mandos y selección.
+
+        Lo usan la casilla «Usar voz sapi» y su revert de Cancelar, para que no
+        puedan separarse. Marcada, quien lee es SAPI 5, que sabe cambiar de voz
+        aunque el motor de debajo sea el lector de pantalla, que no. No hay que
+        mover ninguna voz de sitio: cada estado lee y escribe SU clave (ver
+        _voz_editada).
+        """
         self.dialog.seleccionar_TTS.Enable(not config['sapi'])
         self.actualizar_visibilidad_instalador()
+        # actualizar_filtro_idioma recoloca el filtro en el idioma del programa.
+        # Al desmarcar con kokoro o edge eso dejaba fuera de la lista una voz de
+        # otro idioma, y _seleccionar_voz_activa caía en la primera: un simple
+        # ida y vuelta por la casilla le cambiaba la voz al motor sin decirlo.
+        idioma_voz = None if config['sapi'] else self._idioma_de_voz(config.get('voz', 0))
         self.actualizar_filtro_idioma()
-        # La lista pasa a enseñar las voces del que ahora lee el chat, y los
-        # mandos vuelven a estar vivos: marcada, quien lee es SAPI 5, que sabe
-        # cambiar de voz aunque el motor de debajo sea el lector de pantalla,
-        # que no. No hay que mover ninguna voz de sitio al marcar ni al
-        # desmarcar: cada estado lee y escribe SU clave (ver _voz_editada).
+        if idioma_voz and idioma_voz in self.codigos_idioma:
+            self.dialog.choice_idioma_voz.SetSelection(self.codigos_idioma.index(idioma_voz))
         self._cargar_lista_de_voces()
         self.actualizar_habilitacion_controles()
         self._seleccionar_voz_activa()
@@ -429,7 +443,10 @@ class AjustesController:
         motor que no se oía, y no había forma de elegir la que sí hablaba.
         """
         if config['sapi']:
-            self._mostrar_voces(lista_voces)
+            # Red de seguridad por si el sistema no diera ninguna voz SAPI: una lista
+            # vacía deja al lector de pantalla anunciando un desplegable sin
+            # valor, sin decir por qué.
+            self._mostrar_voces(lista_voces or [_("No hay voces instaladas")])
         elif config['sistemaTTS'] == "piper":
             self._mostrar_voces(lista_voces_piper)
         elif config['sistemaTTS'] == "kokoro":
@@ -496,7 +513,11 @@ class AjustesController:
         wx.CallAfter(self._poblar_voces_edge)
 
     def _poblar_voces_edge(self):
-        if config['sistemaTTS'] != "edge":
+        # Con la casilla marcada la lista es la de SAPI: el catálogo de Edge
+        # puede llegar mientras tanto (se pide al abrir el diálogo) y la
+        # reescribiría entera bajo los dedos del usuario, colocando además la
+        # voz del chat en la posición que tocara.
+        if config['sapi'] or config['sistemaTTS'] != "edge":
             return
         try:
             # El diálogo pudo cerrarse antes de que terminara la descarga: no
@@ -703,7 +724,14 @@ class AjustesController:
         reader._lector.set_volume(value)
         config['volume'] = value
     def cambiarTono(self, event):
-        if config['sistemaTTS'] == "onecore":
+        if config['sapi']:
+            # El tono es el de la voz SAPI que lee el chat. El motor no se toca:
+            # puede ser onecore, cuyo tono va en otra escala (0-4), y escribirle
+            # un valor de esta (-10 a 10) le estropeaba el suyo en silencio.
+            value = self.dialog.slider_1.GetValue() - 10
+            reader._leer.set_pitch(value)
+            config['tono'] = value
+        elif config['sistemaTTS'] == "onecore":
             # OneCore: el slider va de 0 a 4, cada posición = 0.6, 0.7, 0.8, 0.9, 1.0
             pos = self.dialog.slider_1.GetValue()
             config['tono_onecore'] = pos
@@ -890,12 +918,7 @@ class AjustesController:
             # que hay que dejar puesta es la del que habla, no la del elegido.
             try:
                 self.dialog.check_1.SetValue(config['sapi'])
-                self.dialog.seleccionar_TTS.Enable(not config['sapi'])
-                self.actualizar_visibilidad_instalador()
-                self._cargar_lista_de_voces()
-                self.actualizar_habilitacion_controles()
-                self._seleccionar_voz_activa()
-                self.cambiarVoz(None)
+                self._recargar_panel_de_voz()
             except Exception:
                 logger.exception("No se pudo restaurar la casilla «Usar voz sapi» al cancelar Ajustes (sapi=%s)", config['sapi'])
 

--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -48,7 +48,7 @@ class AjustesController:
         'sapi', 'reader', 'traducir', 'interface', 'updates', 'salir', 'donations',
         'sonidos', 'directorio', 'sistemaTTS', 'dispositivo', 'voz', 'volume',
         'tono', 'tono_onecore', 'speed', 'reproducir', 'tiempo', 'volumen', 'cambiovolumen',
-        'voz_piper', 'voz_kokoro', 'voz_edge',
+        'voz_piper', 'voz_kokoro', 'voz_edge', 'voz_sapi',
     ]
 
     def __init__(self, dialog):
@@ -72,22 +72,7 @@ class AjustesController:
         self.actualizar_visibilidad_instalador()
         self.actualizar_filtro_idioma()
         # Cargamos la lista de voces correcta al iniciar
-        if config['sistemaTTS'] == "piper":
-            self._mostrar_voces(lista_voces_piper)
-        elif config['sistemaTTS'] == "kokoro":
-            self.rellenar_voces()
-        elif config['sistemaTTS'] == "edge":
-            # Las voces de Edge viven en el CDN: se descargan en segundo plano
-            # y se rellenan cuando llegan (ver _poblar_voces_edge).
-            if edge_voces_listas():
-                self.rellenar_voces()
-            else:
-                edge_iniciar_carga(self._voces_edge_listas)
-        else:
-            voces = reader._lector.list_voices()
-            if not voces:
-                voces = [_("Controlado por el lector de pantalla")]
-            self._mostrar_voces(voces)
+        self._cargar_lista_de_voces()
         self.actualizar_habilitacion_controles()
         # SetSelection fuera de rango no lanza excepción en wx: colocamos la voz
         # a mano para que el lector de pantalla siempre anuncie una.
@@ -173,9 +158,33 @@ class AjustesController:
         config[key] = True if event.IsChecked() else False
 
     def checar_sapi(self, event):
-        config['sapi'] = True if event.IsChecked() else False
-        self.dialog.seleccionar_TTS.Enable(not event.IsChecked())
+        config['sapi'] = event.IsChecked()
+        self.dialog.seleccionar_TTS.Enable(not config['sapi'])
         self.actualizar_visibilidad_instalador()
+        self.actualizar_filtro_idioma()
+        # La lista pasa a enseñar las voces del que ahora lee el chat, y los
+        # mandos vuelven a estar vivos: marcada, quien lee es SAPI 5, que sabe
+        # cambiar de voz aunque el motor de debajo sea el lector de pantalla,
+        # que no. No hay que mover ninguna voz de sitio al marcar ni al
+        # desmarcar: cada estado lee y escribe SU clave (ver _voz_editada).
+        self._cargar_lista_de_voces()
+        self.actualizar_habilitacion_controles()
+        self._seleccionar_voz_activa()
+        self.cambiarVoz(None)
+
+    def _voz_editada(self):
+        """La voz sobre la que actúa el panel ahora mismo.
+
+        Con la casilla «Usar voz sapi» marcada se edita la voz SAPI 5 que lee el
+        chat, guardada en 'voz_sapi'; si no, la del motor elegido, en 'voz'.
+        Cada una en su clave y ninguna se pisa: config['voz'] tiene que seguir
+        siendo la posición dentro de la lista del motor incluso con la casilla
+        marcada, porque es la que carga el motor al arrancar VeTube.
+        """
+        return config.get('voz_sapi', 0) if config['sapi'] else config.get('voz', 0)
+
+    def _fijar_voz_editada(self, indice):
+        config['voz_sapi' if config['sapi'] else 'voz'] = indice
 
     @staticmethod
     def _clave_voz(motor):
@@ -377,7 +386,10 @@ class AjustesController:
         Microsoft). En ambos se coloca por defecto en el idioma del programa
         (languageHandler.curLang), igual que en el menú principal
         (main_menu_controller, curLang[:2])."""
-        es_multi = config['sistemaTTS'] in ("kokoro", "edge")
+        # Con la casilla «Usar voz sapi» marcada la lista enseña las voces SAPI,
+        # que son las del sistema y no se filtran por idioma: dejar el filtro a
+        # la vista invitaba a recargar encima la lista del motor.
+        es_multi = not config['sapi'] and config['sistemaTTS'] in ("kokoro", "edge")
         self.dialog.label_idioma_voz.Show(es_multi)
         self.dialog.choice_idioma_voz.Show(es_multi)
         if es_multi:
@@ -408,6 +420,33 @@ class AjustesController:
             return self.codigos_idioma[seleccion]
         return None
 
+    def _cargar_lista_de_voces(self):
+        """Llena la lista con las voces que el panel edita en este momento.
+
+        Con la casilla «Usar voz sapi» marcada esas voces son las de SAPI 5, no
+        las del motor elegido: SAPI es quien lee el chat, y el selector de motor
+        está deshabilitado. Sin esto el panel enseñaba y regulaba la voz de un
+        motor que no se oía, y no había forma de elegir la que sí hablaba.
+        """
+        if config['sapi']:
+            self._mostrar_voces(lista_voces)
+        elif config['sistemaTTS'] == "piper":
+            self._mostrar_voces(lista_voces_piper)
+        elif config['sistemaTTS'] == "kokoro":
+            self.rellenar_voces()
+        elif config['sistemaTTS'] == "edge":
+            # Las voces de Edge viven en el CDN: se descargan en segundo plano
+            # y se rellenan cuando llegan (ver _poblar_voces_edge).
+            if edge_voces_listas():
+                self.rellenar_voces()
+            else:
+                edge_iniciar_carga(self._voces_edge_listas)
+        else:
+            voces = reader._lector.list_voices()
+            if not voces:
+                voces = [_("Controlado por el lector de pantalla")]
+            self._mostrar_voces(voces)
+
     def _mostrar_voces(self, etiquetas, indices=None):
         """Llena la lista de voces. indices traduce cada posición mostrada al
         número que se guarda en config['voz']: con Kokoro filtrado por idioma no
@@ -420,11 +459,12 @@ class AjustesController:
         """Deja la lista sobre la voz de config['voz'] y devuelve True. Si esa
         voz no está (índice inservible, o filtrada por idioma), cae en la
         primera de la lista, actualiza config['voz'] y devuelve False."""
-        if config['voz'] in self.indices_voces:
-            self.dialog.choice_2.SetSelection(self.indices_voces.index(config['voz']))
+        voz = self._voz_editada()
+        if voz in self.indices_voces:
+            self.dialog.choice_2.SetSelection(self.indices_voces.index(voz))
             return True
         self.dialog.choice_2.SetSelection(0)
-        config['voz'] = self.indices_voces[0] if self.indices_voces else 0
+        self._fijar_voz_editada(self.indices_voces[0] if self.indices_voces else 0)
         return False
 
     def _indice_global_seleccionado(self):
@@ -432,7 +472,7 @@ class AjustesController:
         seleccion = self.dialog.choice_2.GetSelection()
         if 0 <= seleccion < len(self.indices_voces):
             return self.indices_voces[seleccion]
-        return config['voz']
+        return self._voz_editada()
 
     def rellenar_voces_kokoro(self):
         """Llena la lista con las voces del idioma elegido en el filtro."""
@@ -489,7 +529,19 @@ class AjustesController:
             self.cambiarVoz(None)
 
     def actualizar_habilitacion_controles(self):
-        if config['sistemaTTS'] in ("piper", "kokoro", "edge"):
+        if config['sapi']:
+            # SAPI 5 sabe cambiar de voz, tono, volumen y velocidad, así que los
+            # cuatro mandos van vivos. Hay que decirlo aparte: el motor elegido
+            # puede ser el lector de pantalla, que no sabe hacer casi nada y
+            # dejaba los mandos apagados aunque quien hablase fuera SAPI.
+            if self.dialog.slider_1.GetMax() == 4:
+                self.dialog.slider_1.SetRange(0, 20)
+                self.dialog.slider_1.SetValue(config['tono'] + 10)
+            self.dialog.slider_1.Enable(True)
+            self.dialog.slider_2.Enable(True)
+            self.dialog.slider_3.Enable(True)
+            self.dialog.choice_2.Enable(True)
+        elif config['sistemaTTS'] in ("piper", "kokoro", "edge"):
             # Restaurar slider de tono al rango normal si venía de OneCore
             if self.dialog.slider_1.GetMax() == 4:
                 self.dialog.slider_1.SetRange(0, 20)
@@ -559,7 +611,11 @@ class AjustesController:
             self.reproduciendo_prueba = False
             return
 
-        if config['sistemaTTS'] in ("piper", "kokoro"):
+        if config['sapi']:
+            # La prueba tiene que sonar con la voz que de verdad va a leer el
+            # chat, que con la casilla marcada es la SAPI secundaria.
+            reader._leer.silence()
+        elif config['sistemaTTS'] in ("piper", "kokoro"):
             if config['sistemaTTS'] == "kokoro" and kokoro_voice_config(config['voz']) is None:
                 # Sin el modelo instalado la síntesis no arranca nunca: avisar
                 # de lo que falta y ofrecer el descargador ahí mismo (pedido
@@ -588,7 +644,11 @@ class AjustesController:
         else:
             reader._lector.silence()
 
-        reader.leer_auto(_("Hola, soy la voz que te acompañará de ahora en adelante a leer los mensajes de tus canales favoritos."))
+        saludo = _("Hola, soy la voz que te acompañará de ahora en adelante a leer los mensajes de tus canales favoritos.")
+        if config['sapi']:
+            reader._leer.speak(saludo)
+        else:
+            reader.leer_auto(saludo)
         self.dialog.boton_prueva.SetLabel(_("&Detener prueba."))
         self.reproduciendo_prueba = True
         self.play_timer.Start(200)
@@ -597,11 +657,23 @@ class AjustesController:
         if self.play_timer.IsRunning():
             self.play_timer.Stop()
         reader._lector.silence()
+        if config['sapi']:
+            # Con la casilla marcada la prueba suena por la voz SAPI: callar
+            # solo al motor dejaba la frase anterior encima de la nueva.
+            reader._leer.silence()
         self.dialog.boton_prueva.SetLabel(_("&Reproducir prueba."))
         self.reproduciendo_prueba = False
 
-        config['voz'] = self._indice_global_seleccionado()
-        if config['sistemaTTS'] == "piper":
+        self._fijar_voz_editada(self._indice_global_seleccionado())
+        if config['sapi']:
+            # Quien lee el chat es la voz SAPI secundaria: es a ella a la que
+            # hay que apuntar, no al motor elegido, que está deshabilitado. Y
+            # config['voz'] no se toca: sigue siendo la voz del motor, que es
+            # la que este carga al arrancar VeTube.
+            indice = config['voz_sapi']
+            if lista_voces and indice < len(lista_voces):
+                reader._leer.set_voice(lista_voces[indice])
+        elif config['sistemaTTS'] == "piper":
             from TTS.list_voices import obtener_ruta_voz
             # Simplemente cargamos el nuevo modelo en el lector existente
             reader._lector.load_model(obtener_ruta_voz(lista_voces_piper[config['voz']]))
@@ -706,7 +778,11 @@ class AjustesController:
 
     def on_check_play_status(self, event):
         try:
-            if config['sistemaTTS'] in ("piper", "kokoro", "edge"):
+            if config['sapi']:
+                # La prueba salió por la voz SAPI: es a ella a quien hay que
+                # preguntar, si no el botón se queda en «Detener» para siempre.
+                sigue_hablando = reader._leer.backend.speaking
+            elif config['sistemaTTS'] in ("piper", "kokoro", "edge"):
                 sigue_hablando = reader._lector.is_playing()
             else:
                 sigue_hablando = reader._lector.backend.speaking
@@ -721,7 +797,9 @@ class AjustesController:
         if hasattr(self, 'play_timer') and self.play_timer.IsRunning():
             self.play_timer.Stop()
         try:
-            reader._lector.silence()
+            # Las dos: la prueba puede haber salido por la voz SAPI (casilla
+            # marcada) y cerrar el diálogo no debe dejarla hablando sola.
+            reader.silence()
         except Exception:
             pass
         event.Skip()
@@ -737,7 +815,14 @@ class AjustesController:
         demás, y no debe fallar en silencio — se registra con logger.exception."""
         original = self.config_al_abrir
         cambio_tts = config.get('sistemaTTS') != original['sistemaTTS']
-        cambio_voz = config.get('voz') != original['voz']
+        # Hay que anotarlo aquí, como los demás: el bucle de abajo devuelve
+        # config a los valores de apertura, y después ya no habría diferencia
+        # que detectar.
+        cambio_sapi = config.get('sapi') != original['sapi']
+        # Las dos voces: con la casilla marcada lo que se toca es voz_sapi, y
+        # mirar solo 'voz' dejaba sin deshacer el cambio de voz del chat.
+        cambio_voz = (config.get('voz') != original['voz']
+                      or config.get('voz_sapi') != original['voz_sapi'])
         cambio_volumen = config.get('volume') != original['volume']
         cambio_tono = (config.get('tono') != original['tono']) or (config.get('tono_onecore') != original['tono_onecore'])
         cambio_velocidad = config.get('speed') != original['speed']
@@ -759,9 +844,16 @@ class AjustesController:
                 self.cambiar_sintetizador(None)
             except Exception:
                 logger.exception("No se pudo restaurar el sistema TTS al cancelar Ajustes (sistemaTTS=%s)", config['sistemaTTS'])
-        elif cambio_voz:
+        elif cambio_voz and not cambio_sapi:
+            # Si la casilla ha cambiado no se entra aquí: es su bloque, más
+            # abajo, quien recarga la lista y vuelve a aplicar la voz — y sabe
+            # además cuál de las dos listas toca. Entrar aquí antes buscaba la
+            # voz en la lista del motor y avisaba de un índice fuera de rango
+            # que no significaba nada.
             try:
-                if config['sistemaTTS'] == "piper":
+                if config['sapi']:
+                    lista_voces_actual = lista_voces
+                elif config['sistemaTTS'] == "piper":
                     lista_voces_actual = lista_voces_piper
                 elif config['sistemaTTS'] == "kokoro":
                     lista_voces_actual = kokoro_list_voices()
@@ -769,8 +861,9 @@ class AjustesController:
                     lista_voces_actual = edge_list_voices()
                 else:
                     lista_voces_actual = reader._lector.list_voices()
-                if 0 <= config['voz'] < len(lista_voces_actual):
-                    if config['sistemaTTS'] in ("kokoro", "edge"):
+                voz_a_restaurar = self._voz_editada()
+                if 0 <= voz_a_restaurar < len(lista_voces_actual):
+                    if not config['sapi'] and config['sistemaTTS'] in ("kokoro", "edge"):
                         # La lista puede haber quedado filtrada por otro idioma:
                         # hay que devolverla al idioma de la voz original, si no
                         # esta no aparece y se recargaría cualquier otra.
@@ -784,10 +877,27 @@ class AjustesController:
                     # para no terminar cargando una voz cualquiera (indexación negativa de Python).
                     logger.warning(
                         "No se pudo restaurar la voz al cancelar Ajustes: índice %s fuera de rango (%s voces disponibles)",
-                        config['voz'], len(lista_voces_actual),
+                        voz_a_restaurar, len(lista_voces_actual),
                     )
             except Exception:
                 logger.exception("No se pudo restaurar la voz al cancelar Ajustes (voz=%s)", config['voz'])
+
+        if cambio_sapi:
+            # La casilla se revierte sola con CLAVES_EN_CALIENTE, pero lo que
+            # ya se aplicó no: la lista enseñaría las voces del otro y, sobre
+            # todo, la voz que se probó se quedaría puesta en quien no debía.
+            # Va después del bloque del motor porque manda sobre él: la lista
+            # que hay que dejar puesta es la del que habla, no la del elegido.
+            try:
+                self.dialog.check_1.SetValue(config['sapi'])
+                self.dialog.seleccionar_TTS.Enable(not config['sapi'])
+                self.actualizar_visibilidad_instalador()
+                self._cargar_lista_de_voces()
+                self.actualizar_habilitacion_controles()
+                self._seleccionar_voz_activa()
+                self.cambiarVoz(None)
+            except Exception:
+                logger.exception("No se pudo restaurar la casilla «Usar voz sapi» al cancelar Ajustes (sapi=%s)", config['sapi'])
 
         if cambio_volumen:
             try:

--- a/controller/kokoro_downloader_controller.py
+++ b/controller/kokoro_downloader_controller.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import wx
 from setup import network, reader
-from globals.data_store import config
+from globals.data_store import config, motor_de_interfaz
 from servicios.kokoro_manager import KokoroManager, TAMANO_DESCARGA
 from ui.kokoro_downloader import KokoroDownloaderDialog
 from TTS.sherpa_handler import kokoro_model_instalado, kokoro_voice_config
@@ -85,7 +85,7 @@ class KokoroDownloaderController:
     def _recargar_voz_activa(self):
         """Si Kokoro es el sistema activo, carga la voz recién instalada para
         que funcione al momento, sin tener que reabrir los Ajustes."""
-        if config.get('sistemaTTS') != "kokoro":
+        if motor_de_interfaz() != "kokoro":
             return
         config_kokoro = kokoro_voice_config(config.get('voz', 0))
         if config_kokoro is not None:

--- a/controller/main_controller.py
+++ b/controller/main_controller.py
@@ -1,5 +1,5 @@
 import wx
-from globals.data_store import favorite, mensajes_destacados, favs, msjs,config
+from globals.data_store import favorite, mensajes_destacados, favs, msjs,config,motor_de_interfaz
 from globals.paths import FAVORITOS_FILE, MENSAJES_DESTACADOS_FILE
 from ui.main_window import MyFrame, PLATAFORMAS
 from os import remove
@@ -34,7 +34,7 @@ class MainController:
 
     def iniciar_secuencia_arranque(self):
         # 1. Verificar e instalar voces si es necesario
-        if config.get('sistemaTTS') == "piper": configurar_piper(self.frame, carpeta_voces)
+        if motor_de_interfaz() == "piper": configurar_piper(self.frame, carpeta_voces)
         # 2. Comprobar actualizaciones en segundo plano de forma segura
         if config.get('updates', False):
             updater.do_update()

--- a/controller/menus/main_menu_controller.py
+++ b/controller/menus/main_menu_controller.py
@@ -166,7 +166,10 @@ class MainMenuController:
         reader._leer.set_volume(data_store.config['volume'])
         voices_leer = reader._leer.list_voices()
         if voices_leer:
-            idx = data_store.config['voz']
+            # La voz SAPI tiene su propia clave: config['voz'] es la posición
+            # dentro de la lista del motor elegido, y aplicarla aquí cargaba
+            # una voz SAPI cualquiera (o la primera, al salirse de rango).
+            idx = data_store.config.get('voz_sapi', 0)
             if idx >= len(voices_leer): idx = 0
             reader._leer.set_voice(voices_leer[idx])
         

--- a/controller/menus/main_menu_controller.py
+++ b/controller/menus/main_menu_controller.py
@@ -58,7 +58,7 @@ class MainMenuController:
         # Pedido de César (2026-08-01): al Aceptar con Kokoro elegido y sin el
         # modelo en el equipo, ofrecer la descarga en el acto — así el paquete
         # de 334 MB solo lo baja quien de verdad va a usar estas voces.
-        if resultado == wx.ID_OK and data_store.config['sistemaTTS'] == "kokoro" and not kokoro_model_instalado():
+        if resultado == wx.ID_OK and data_store.motor_de_interfaz() == "kokoro" and not kokoro_model_instalado():
             KokoroDownloaderController(self.frame).show()
 
     def restaurar(self, event):
@@ -173,19 +173,22 @@ class MainMenuController:
             if idx >= len(voices_leer): idx = 0
             reader._leer.set_voice(voices_leer[idx])
         
-        if data_store.config['sistemaTTS'] in ("piper", "kokoro"):
+        # El motor que lee el programa, no el elegido en la lista: con la
+        # casilla «Usar voz sapi» marcada quien lee es el lector de pantalla.
+        motor = data_store.motor_de_interfaz()
+        if motor in ("piper", "kokoro"):
             # Los dos puentes usan la escala porcentaje_a_escala y no exponen list_voices
             reader._lector.set_rate(app_utilitys.porcentaje_a_escala(data_store.config['speed']))
             reader._lector.set_pitch(data_store.config['tono'])
             reader._lector.set_volume(data_store.config['volume'])
-        elif data_store.config['sistemaTTS'] == "edge":
+        elif motor == "edge":
             # Edge: la velocidad va nativa (-10 a 10) a edge-tts
             reader._lector.set_rate(data_store.config['speed'])
             reader._lector.set_pitch(data_store.config['tono'])
             reader._lector.set_volume(data_store.config['volume'])
         else:
             reader._lector.set_rate(data_store.config['speed'])
-            if data_store.config['sistemaTTS'] == "onecore":
+            if motor == "onecore":
                 reader._lector.set_pitch(data_store.config.get('tono_onecore', 0.6))
             else:
                 reader._lector.set_pitch(data_store.config['tono'])
@@ -197,11 +200,11 @@ class MainMenuController:
                 reader._lector.set_voice(voices_lector[idx])
 
         reader.set_sapi(data_store.config['sapi'])
-        if data_store.config['sistemaTTS'] in ("piper", "kokoro"):
+        if motor in ("piper", "kokoro"):
             app_utilitys.fijar_dispositivo_lector()
-            if data_store.config['sistemaTTS'] == "piper":
+            if motor == "piper":
                 app_utilitys.configurar_piper(self.frame, carpeta_voces)
-        elif data_store.config['sistemaTTS'] == "edge":
+        elif motor == "edge":
             app_utilitys.fijar_dispositivo_lector()
         if cf.choice_moneditas.GetStringSelection()!='Por defecto':
             monedita=cf.choice_moneditas.GetStringSelection().split(', (')

--- a/globals/data_store.py
+++ b/globals/data_store.py
@@ -13,6 +13,29 @@ favorite = funciones.leerJsonLista(FAVORITOS_FILE)
 mensajes_destacados = funciones.leerJsonLista(MENSAJES_DESTACADOS_FILE)
 favs = funciones.convertirLista(favorite, 'titulo', 'url')
 msjs = funciones.convertirLista(mensajes_destacados, 'mensaje', 'titulo')
+
+def motor_de_interfaz(ajustes=None):
+    """El motor que lee el programa, que no siempre es config['sistemaTTS'].
+
+    La casilla «Usar voz sapi» aparta el motor elegido: marcada, el chat sale
+    por la voz SAPI 5 secundaria y el programa vuelve a leerlo el lector de
+    pantalla, que es lo que significa «auto». Así la casilla se basta sola —
+    marcarla no obliga a ir antes a la lista a elegir «auto»— y config
+    ['sistemaTTS'] guarda mientras tanto el motor al que volver al desmarcarla.
+
+    Quien pregunte qué motor habla, qué modelo cargar o qué enseñar en los
+    Ajustes tiene que preguntar aquí; config['sistemaTTS'] a secas solo vale
+    para saber qué eligió el usuario en la lista.
+
+    Con `ajustes` se pregunta por otra foto de la configuración en vez de por
+    la de ahora: lo usa Cancelar en los Ajustes, que compara el motor que habla
+    con el que había al abrir el diálogo. Así la regla vive en un solo sitio.
+    """
+    if ajustes is None:
+        ajustes = config
+    return "auto" if ajustes.get('sapi') else ajustes['sistemaTTS']
+
+
 divisa="Por defecto"
 # La traducción de mensajes no es persistente: arranca desactivada en cada sesión (se ajusta desde el diálogo)
 dst = ""

--- a/helpers/reader_handler.py
+++ b/helpers/reader_handler.py
@@ -1,5 +1,5 @@
 import os
-from globals.data_store import config
+from globals.data_store import config, motor_de_interfaz
 from prism import Context, BackendId
 
 # Instancia única del contexto de Prism para compartir recursos
@@ -86,7 +86,7 @@ class PrismBackendWrapper:
 
 class ReaderHandler:
     def __init__(self, lector=None):
-        sistema = config['sistemaTTS'] if lector is None else lector
+        sistema = motor_de_interfaz() if lector is None else lector
         # TODOS los lectores pasan por configurar_tts, también los que no usan
         # ningún puente: es ahí donde se cierran los puentes de los demás. Si
         # sapi5/onecore/auto se construyeran aquí, el servidor del motor
@@ -139,11 +139,12 @@ class ReaderHandler:
     def leer_sapi(self, mensaje):
         """Avisos del programa: «Ingresando al chat», errores de conexión…
 
-        Salen por el motor activo cuando ese motor tiene voz propia, y caen en
-        la voz SAPI secundaria con auto, sapi5 y onecore. No mira la casilla:
-        estos avisos no son chat.
+        Salen por el motor que lee el programa cuando ese motor tiene voz
+        propia, y caen en la voz SAPI secundaria con auto, sapi5 y onecore —o
+        sea también con la casilla marcada, que devuelve el programa al lector
+        de pantalla y no le deja voz propia (ver motor_de_interfaz).
         """
-        if config['sistemaTTS'] in ("piper", "kokoro", "edge"):
+        if motor_de_interfaz() in ("piper", "kokoro", "edge"):
             self.leer_auto(mensaje)
         else:
             self._leer.speak(mensaje)

--- a/helpers/reader_handler.py
+++ b/helpers/reader_handler.py
@@ -121,12 +121,28 @@ class ReaderHandler:
         config['sapi'] = sapi
 
     def leer_mensaje(self, mensaje):
+        """El chat: los mensajes y los eventos del directo.
+
+        Con la casilla «Usar voz sapi» marcada salen por la voz SAPI 5
+        secundaria y por ahí solamente, tenga el usuario el motor que tenga.
+        Eso es justo lo que la casilla ofrece: una segunda voz que lee el chat
+        mientras el lector de pantalla sigue libre para moverse por el
+        programa. Habla con _leer directamente y no llamando a leer_sapi()
+        porque ese otro camino lleva los avisos del programa, donde la
+        excepción de piper/kokoro/edge sí tiene sentido (ver leer_sapi).
+        """
         if config['sapi']:
-            self.leer_sapi(mensaje)
+            self._leer.speak(mensaje)
         else:
             self.leer_auto(mensaje)
 
     def leer_sapi(self, mensaje):
+        """Avisos del programa: «Ingresando al chat», errores de conexión…
+
+        Salen por el motor activo cuando ese motor tiene voz propia, y caen en
+        la voz SAPI secundaria con auto, sapi5 y onecore. No mira la casilla:
+        estos avisos no son chat.
+        """
         if config['sistemaTTS'] in ("piper", "kokoro", "edge"):
             self.leer_auto(mensaje)
         else:

--- a/run_main_window.py
+++ b/run_main_window.py
@@ -3,7 +3,7 @@
 from utils.logging_setup import configurar_logs
 configurar_logs()
 import asyncio,sys,wx,setup
-from globals.data_store import config
+from globals.data_store import config, motor_de_interfaz
 from globals.resources import carpeta_voces,lista_voces_piper
 from controller.main_controller import MainController
 from update import updater,update
@@ -13,12 +13,15 @@ if sys.platform == "win32": asyncio.set_event_loop_policy(asyncio.WindowsSelecto
 
 def run_app():
     app = wx.App(False)
-    if config['sistemaTTS'] in ("piper", "kokoro"):
+    # El motor que lee el programa, no el elegido en la lista: con la casilla
+    # «Usar voz sapi» marcada no hay ningún modelo local que cargar.
+    motor = motor_de_interfaz()
+    if motor in ("piper", "kokoro"):
         # Cada motor tiene su propio puente (sonata para Piper, sherpa para
         # Kokoro) y setup.reader ya arrancó el que toca: aquí solo hay que
         # localizar la voz configurada y cargarla en el proceso residente.
         modelo = None
-        if config['sistemaTTS'] == "piper":
+        if motor == "piper":
             if detect_onnx_models(carpeta_voces) is not None:
                 from TTS.list_voices import obtener_ruta_voz
                 if not (0 <= config['voz'] < len(lista_voces_piper)):
@@ -30,11 +33,11 @@ def run_app():
         if modelo is not None:
             setup.reader._lector.load_model(modelo)
             fijar_dispositivo_lector()
-        elif config['sistemaTTS'] == "kokoro":
+        elif motor == "kokoro":
             # Modelo Kokoro no disponible: avisar con la voz secundaria en lugar
             # de arrancar con la voz principal muda (revisión de accesibilidad).
             setup.reader._leer.speak(_("No hay voces instaladas"))
-    elif config['sistemaTTS'] == "edge":
+    elif motor == "edge":
         # Edge no tiene modelo local: basta con apuntar el lector al nombre
         # corto de la voz elegida y fijar el dispositivo de salida.
         from TTS.edge_handler import edge_voz_shortname, edge_iniciar_carga, edge_list_voices

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from utils import languageHandler
-from globals.data_store import config
+from globals.data_store import config, motor_de_interfaz
 from players.sound_helper import SoundPlayer
 from helpers.reader_handler import ReaderHandler
 languageHandler.setLanguage(config['idioma'])
@@ -14,12 +14,18 @@ reader._leer.set_pitch(config['tono'])
 reader._leer.set_volume(config['volume'])
 voices_leer = reader._leer.list_voices()
 if voices_leer:
-    idx = config['voz']
+    # La voz SAPI tiene su propia clave: config['voz'] es la posición dentro de
+    # la lista del motor elegido, y aplicarla aquí cargaba una voz SAPI
+    # cualquiera (o la primera, al salirse de rango).
+    idx = config.get('voz_sapi', 0)
     if idx >= len(voices_leer): idx = 0
     reader._leer.set_voice(voices_leer[idx])
 
-# Configurar el lector principal según el motor elegido
-if config['sistemaTTS'] in ("piper", "kokoro"):
+# Configurar el lector principal según el motor que lee el programa (con la
+# casilla «Usar voz sapi» marcada vuelve a leerlo el lector de pantalla, aunque
+# en la lista siga elegido otro motor).
+motor = motor_de_interfaz()
+if motor in ("piper", "kokoro"):
     # Los dos puentes (sonata para Piper, sherpa para Kokoro) guardan los
     # parámetros y los aplican en cada speak; la voz se carga en
     # run_main_window. Misma escala que app_utilitys.porcentaje_a_escala (no se
@@ -27,7 +33,7 @@ if config['sistemaTTS'] in ("piper", "kokoro"):
     reader._lector.set_rate(1.25 + config['speed'] * 0.125)
     reader._lector.set_pitch(config['tono'])
     reader._lector.set_volume(config['volume'])
-elif config['sistemaTTS'] == "edge":
+elif motor == "edge":
     # Edge guarda los parámetros y los aplica en cada speak; la voz se carga
     # en run_main_window. La velocidad va nativa (-10 a 10) a edge-tts.
     reader._lector.set_rate(config['speed'])
@@ -35,7 +41,7 @@ elif config['sistemaTTS'] == "edge":
     reader._lector.set_volume(config['volume'])
 else:
     reader._lector.set_rate(config['speed'])
-    if config['sistemaTTS'] == "onecore":
+    if motor == "onecore":
         reader._lector.set_pitch(config.get('tono_onecore', 0.6))
     else:
         reader._lector.set_pitch(config['tono'])

--- a/utils/app_utilitys.py
+++ b/utils/app_utilitys.py
@@ -22,7 +22,8 @@ def restart_program():
     os.execv(sys.executable, args)
 def porcentaje_a_escala(porcentaje): return 1.25 + porcentaje * 0.125
 def fijar_dispositivo_lector():
-    """Fija en el motor de voz activo (sonata o sherpa, según config['sistemaTTS'])
+    """Fija en el motor de voz activo (sonata o sherpa, según motor_de_interfaz(),
+    que no es config['sistemaTTS'] cuando manda la casilla «Usar voz sapi»)
     la salida de audio que marca config['dispositivo'] (1 = el primero de la
     lista, igual que para el player).
 

--- a/utils/fajustes.py
+++ b/utils/fajustes.py
@@ -12,6 +12,11 @@ configuraciones ={
 	'voz_piper': 0,
 	'voz_kokoro': 0,
 	'voz_edge': 0,
+	# La voz SAPI 5 que lee el chat cuando la casilla «Usar voz sapi» está
+	# marcada. Aparte por lo mismo que las otras tres: su lista no tiene nada
+	# que ver con la del motor elegido, y sin clave propia marcar la casilla y
+	# desmarcarla le cambiaba la voz al motor de debajo.
+	'voz_sapi': 0,
 	"tono": 0,
 	'tono_onecore': 0,
 	"volume": 100,

--- a/utils/fajustes.py
+++ b/utils/fajustes.py
@@ -64,6 +64,22 @@ def leerConfiguracion():
 			# Completar listas que crecieron en versiones nuevas, conservando las preferencias existentes (evita IndexError)
 			configs[clave] = configs[clave] + valor_pred[len(configs[clave]):]
 			actualizar_configuracion = True
+	# Migración única de la casilla «Usar voz sapi», que vuelve a mandar sobre
+	# el chat. Viene marcada de fábrica, y desde la 3.8 no hacía nada con
+	# piper, kokoro ni edge: un True junto a uno de esos motores no es una
+	# elección del usuario, es el valor que nadie tenía motivo de tocar. Sin
+	# esto, quien eligió Piper actualizaría y se encontraría el chat leído por
+	# SAPI 5 sin haber pedido nada.
+	# Con «auto» se queda marcada a propósito: ahí la casilla sí funcionaba (el
+	# chat ya salía por la voz SAPI secundaria), y desmarcarla le cambiaría la
+	# voz a quien no ha pedido nada.
+	# El testigo evita repetirlo: quien marque la casilla a propósito con un
+	# motor elegido se la encontrará marcada en el siguiente arranque.
+	if 'sapi_migrado' not in configs:
+		if configs.get('sapi') and configs.get('sistemaTTS', "auto") != "auto":
+			configs['sapi'] = False
+		configs['sapi_migrado'] = True
+		actualizar_configuracion = True
 	# actualizar al archivo en caso de ser necesario:
 	if actualizar_configuracion:
 		with open(DATA_FILE, 'w+') as file:


### PR DESCRIPTION
> **Esta PR está reescrita.** La versión anterior llevaba toda la aplicación a SAPI 5 y tocaba diez ficheros. Después de probarla, preferimos el reparto de la 3.7: SAPI 5 lee el chat, el lector de pantalla se queda con el programa. Quedan dos ficheros y ninguna cadena traducida. Abajo respondo también a tus dos preguntas.

## Qué hace la casilla

Marcada, los mensajes y los eventos del directo salen por la voz SAPI 5 secundaria, tenga el usuario el motor que tenga; y el programa —menús, Ajustes, «Mensaje copiado», los atajos de mensaje anterior y siguiente— vuelve a leerlo el lector de pantalla. Eso es lo que la casilla ofrece desde siempre: una segunda voz que lee el chat mientras el lector de pantalla sigue libre para moverse por el programa.

La casilla se basta sola: no hay que ir antes a la lista de sistemas TTS a elegir «auto». El motor elegido se aparta mientras está marcada y vuelve al desmarcarla; `config['sistemaTTS']` lo guarda entretanto, que es lo que sigue enseñando el selector. La regla vive en un solo sitio, `globals/data_store.py:motor_de_interfaz()`, y de ahí beben el arranque, el Aceptar de los Ajustes, el descargador de Kokoro y los avisos del programa. Con la casilla marcada tampoco se carga ya el modelo de Kokoro, que son 350 MB de nada.

## Por qué no lo hacía

Desde `fb23577`, `leer_mensaje()` delegaba en `leer_sapi()`, y ahí una excepción devolvía el texto al motor activo cuando ese motor era piper, kokoro o edge:

```python
def leer_sapi(self, mensaje):
    if config['sistemaTTS'] in ("piper", "kokoro", "edge"):
        self.leer_auto(mensaje)
    else:
        self._leer.speak(mensaje)
```

Me corrijo respecto a lo que te dije por WhatsApp: **la casilla no estaba muerta del todo.** Con `auto`, `sapi5` y `onecore` seguía funcionando. Estaba muerta solo para quien había elegido un motor de verdad, o sea para quien más motivo tenía de usarla.

`leer_mensaje()` habla ahora con la voz secundaria directamente. No pasa por `leer_sapi()` porque ese camino lleva los avisos del programa («Ingresando al chat», errores de conexión), donde la excepción sí tiene sentido: un motor con voz propia debe anunciarlos él. **Esos avisos quedan exactamente como estaban.**

## Migración, porque la casilla viene marcada de fábrica

`'sapi': True` es el valor de fábrica en `utils/fajustes.py`. Sin migración, quien eligió Piper actualizaría y se encontraría el chat leído por SAPI 5 sin haber pedido nada.

Un `True` junto a piper, kokoro o edge no es una elección del usuario: es el valor que nadie tenía motivo de tocar, porque no hacía nada. La migración lo desmarca una sola vez, con testigo. Con `auto` se queda marcada a propósito: ahí la casilla ya funcionaba, y desmarcarla le cambiaría la voz a quien no ha pedido nada. El testigo respeta a quien la marque a propósito más adelante.

## Tus dos preguntas

**El texto de la casilla.** Ya no hace falta cambiarlo con urgencia: la casilla no apaga el sistema TTS elegido, solo desvía el chat, así que «Usar voz sapi en lugar de lector de pantalla» vuelve a ser exacto en el caso normal —motor `auto`, que es el lector de pantalla, y es además el único donde la migración deja la casilla marcada—.

Pero me corrijo a medias, que es lo que salió al repasar la accesibilidad: si alguien elige Piper y marca la casilla a mano, lo que sustituye no es el lector de pantalla, es Piper. Ahí el texto sigue mintiendo un poco, como ya mentía en la 3.7. Si quieres afinarlo, algo como «Leer el chat con una voz SAPI 5 en lugar del motor elegido» lo diría entero. Como cuesta los siete catálogos y la cadena vieja ya está traducida en todos, lo dejo a tu criterio y no lo toco en esta PR.

**«¿Qué pasa si leo mensajes con el atajo de siguiente mensaje o mensaje anterior?»** Salen por el lector de pantalla, no por SAPI. `elementoAnterior` y `elementoSiguiente` llaman a `leer_auto()` (`controller/chat_controller.py`), o sea al lector principal, que con la casilla marcada es el lector de pantalla. Es el reparto de la 3.7 y lo dejamos así a propósito: moverse por la lista es navegar por el programa. La voz SAPI se reserva a lo que llega solo.

Probado: releyendo el historial con alt+shift+flechas durante una partida, NVDA. Queda una consecuencia que te señalo por si prefieres otra cosa: al ser dos voces independientes, un mensaje que entra mientras uno relee el historial se superpone en vez de interrumpir. El atajo de espacio sí calla a las dos (`reader.silence()`); se podría hacer lo mismo en las flechas, pero es una decisión de uso y no la tomo yo.

## Y los Ajustes pasan a hablar de esa voz

Con la casilla marcada, el panel seguía enseñando las voces del motor elegido —y con `auto` ni eso: «Controlado por el lector de pantalla», lista deshabilitada—. O sea que quien la marcaba no tenía forma de elegir la voz que le iba a leer el chat, ni de probarla: se quedaba con la primera del sistema. Es lo que hacía inservible el arreglo a secas.

Marcada, ahora: la lista enseña las voces SAPI 5, los cuatro mandos van vivos (SAPI sabe cambiar voz, tono, volumen y velocidad, aunque el motor de debajo sea el lector de pantalla, que no), la prueba suena por esa voz, y el filtro de idioma se esconde.

La voz SAPI vive en su clave, `voz_sapi`, como ya hacían piper, kokoro y edge. Así `config['voz']` sigue siendo la posición dentro de la lista del motor incluso con la casilla marcada, que es la que el motor carga al arrancar: pisarla con un índice SAPI le cambiaba la voz al usuario (caso real, edge con la voz 130 → 0 al abrir Ajustes). Como cada estado lee y escribe su clave, marcar y desmarcar ya no mueve ninguna voz de sitio.

## Comprobado

Dos bancos en local. El primero, 34 comprobaciones: los seis motores mandan el chat a SAPI con la casilla marcada; los avisos no cambian en las doce combinaciones de motor y casilla; la navegación sigue en `leer_auto`; y los cinco casos de migración caen donde deben, incluido el testigo.

Pasó además un repaso de accesibilidad, que sacó tres fallos silenciosos ya corregidos: el mando de tono se le iba al motor cuando debajo había onecore (y de paso le estropeaba su tono al usuario), el catálogo de Edge reescribía la lista por debajo unos segundos después de marcar la casilla, y marcar y desmarcar le cambiaba la voz al motor si era de un idioma distinto al del programa.

El segundo banco abre el diálogo de Ajustes de verdad (sin mostrarlo) y comprueba, con los cinco motores, que marcada enseña las voces SAPI con los mandos vivos y sin filtro de idioma, que desmarcar devuelve la lista del motor con su voz intacta, que abrir con la casilla ya marcada no pisa la voz del motor, y que Cancelar lo deja todo como estaba.

Y probado con NVDA sobre la aplicación real: Enzo jugó una partida en el Salón con la casilla marcada y Edge elegido. Los mensajes le llegaron por la voz SAPI, y el programa —incluido releer el historial con alt+shift+flechas— se lo leyó NVDA. El reparto es el que se buscaba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
