### PR TITLE
Tres familias de voz en vez de dos mal separadas: el chat, el programa y las pruebas

### DIFF
--- a/controller/ajustes_controller.py
+++ b/controller/ajustes_controller.py
@@ -625,10 +625,10 @@ class AjustesController:
                 # La lista del diálogo se construye con player.devicenames, así que
                 # el nombre elegido y el que saca config['dispositivo'] son el mismo.
                 app_utilitys.fijar_dispositivo_lector()
-            reader.leer_auto(_("Hablaré a través de este dispositivo."))
+            reader.leer_motor(_("Hablaré a través de este dispositivo."))
         elif motor == "edge":
             app_utilitys.fijar_dispositivo_lector()
-            reader.leer_auto(_("Hablaré a través de este dispositivo."))
+            reader.leer_motor(_("Hablaré a través de este dispositivo."))
 
     def reproducirPrueva(self, event):
         # El botón alterna entre reproducir y detener con cualquier motor:
@@ -674,10 +674,10 @@ class AjustesController:
             reader._lector.silence()
 
         saludo = _("Hola, soy la voz que te acompañará de ahora en adelante a leer los mensajes de tus canales favoritos.")
-        if config['sapi']:
-            reader._leer.speak(saludo)
-        else:
-            reader.leer_auto(saludo)
+        # La prueba tiene que sonar por la voz que va a leer el chat, que es lo
+        # que la frase promete y lo que enseña la lista de voces de al lado:
+        # con la casilla marcada, la voz SAPI 5.
+        reader.leer_mensaje(saludo)
         self.dialog.boton_prueva.SetLabel(_("&Detener prueba."))
         self.reproduciendo_prueba = True
         self.play_timer.Start(200)

--- a/controller/chat_controller.py
+++ b/controller/chat_controller.py
@@ -117,7 +117,7 @@ class ChatController:
             if list_box.GetSelection() == wx.NOT_FOUND:
                 return
             reader.silence()
-            reader.leer_auto(list_box.GetString(list_box.GetSelection()))
+            reader.leer_interfaz(list_box.GetString(list_box.GetSelection()))
 
     def agregar_mensaje_general(self, mensaje):
         if hasattr(self.ui, 'list_box_general'):
@@ -206,7 +206,7 @@ class ChatController:
         if next_selection >= page_count:
             next_selection = 0
         self.ui.treebook.SetSelection(next_selection)
-        reader.leer_auto(self.ui.treebook.GetPageText(next_selection))
+        reader.leer_interfaz(self.ui.treebook.GetPageText(next_selection))
 
     def retrocederCategorias(self):
         if not self.ui: return
@@ -217,7 +217,7 @@ class ChatController:
         if next_selection < 0:
             next_selection = page_count - 1
         self.ui.treebook.SetSelection(next_selection)
-        reader.leer_auto(self.ui.treebook.GetPageText(next_selection))
+        reader.leer_interfaz(self.ui.treebook.GetPageText(next_selection))
 
     def elementoAnterior(self):
         listbox = self.current_listbox
@@ -229,7 +229,7 @@ class ChatController:
             selection -= 1
         listbox.SetSelection(selection)
         self.reproducirMsg()
-        reader.leer_auto(listbox.GetString(selection))
+        reader.leer_interfaz(listbox.GetString(selection))
 
     def elementoSiguiente(self):
         listbox = self.current_listbox
@@ -241,7 +241,7 @@ class ChatController:
             selection += 1
         listbox.SetSelection(selection)
         self.reproducirMsg()
-        reader.leer_auto(listbox.GetString(selection))
+        reader.leer_interfaz(listbox.GetString(selection))
 
     def reproducirMsg(self):
         listbox = self.current_listbox
@@ -258,7 +258,7 @@ class ChatController:
         if not listbox or listbox.GetCount() == 0: return
         listbox.SetSelection(0)
         self.reproducirMsg()
-        reader.leer_auto(listbox.GetString(0))
+        reader.leer_interfaz(listbox.GetString(0))
 
     def elemento_final(self):
         listbox = self.current_listbox
@@ -266,14 +266,14 @@ class ChatController:
         last_index = listbox.GetCount() - 1
         listbox.SetSelection(last_index)
         self.reproducirMsg()
-        reader.leer_auto(listbox.GetString(last_index))
+        reader.leer_interfaz(listbox.GetString(last_index))
 
     def copiarMensajeActual(self):
         listbox = self.current_listbox
         if not listbox or listbox.GetSelection() == wx.NOT_FOUND: return
         selected_text = listbox.GetString(listbox.GetSelection())
         copy(selected_text)
-        reader.leer_auto(_("Mensaje copiado"))
+        reader.leer_aviso(_("Mensaje copiado"))
 
     def mostrar_mensaje_actual(self):
         listbox = self.current_listbox
@@ -293,10 +293,10 @@ class ChatController:
             self.ui.list_box_favoritos.Bind(wx.EVT_CONTEXT_MENU, self.on_context_menu)
             self.ui.list_box_favoritos.Bind(wx.EVT_KEY_UP, self.on_listbox_keyup)
         if mensaje in self.ui.list_box_favoritos.GetStrings():
-            reader.leer_auto(_("Este mensaje ya se encuentra en favoritos"))
+            reader.leer_aviso(_("Este mensaje ya se encuentra en favoritos"))
             return
         self.ui.list_box_favoritos.Append(mensaje)
-        reader.leer_auto(_("Mensaje agregado a favoritos"))
+        reader.leer_aviso(_("Mensaje agregado a favoritos"))
 
     def archivar_mensaje(self):
         listbox = self.current_listbox
@@ -324,20 +324,20 @@ class ChatController:
             data_store.mensajes_destacados.append({'mensaje': mensaje, 'titulo': titulo})
             
             escribirJsonLista(MENSAJES_DESTACADOS_FILE, data_store.mensajes_destacados)
-            reader.leer_auto(_("El mensaje ha sido archivado correctamente."))
+            reader.leer_aviso(_("El mensaje ha sido archivado correctamente."))
         else: 
-            reader.leer_sapi(_("Este mensaje ya está en la lista de archivados."))
+            reader.leer_aviso(_("Este mensaje ya está en la lista de archivados."))
 
     def borrar_pagina_actual(self):
         page_index = self.ui.treebook.GetSelection()
         page_count = self.ui.treebook.GetPageCount()
 
         if page_count <= 1:
-            reader.leer_auto(_("No se puede borrar la última página."))
+            reader.leer_aviso(_("No se puede borrar la última página."))
             return
 
         self.ui.treebook.DeletePage(page_index)
-        reader.leer_auto(_("Página borrada."))
+        reader.leer_aviso(_("Página borrada."))
         self.actualizar_estado_boton_eliminar()
 
     def toggle_lectura_automatica(self):
@@ -345,9 +345,9 @@ class ChatController:
             reader.silence()
             data_store.config['reader'] = False
         else: data_store.config['reader'] = True
-        reader.leer_auto(_("Lectura automática activada.") if data_store.config['reader'] else _("Lectura automática desactivada."))
+        reader.leer_aviso(_("Lectura automática activada.") if data_store.config['reader'] else _("Lectura automática desactivada."))
 
     def toggle_sounds(self):
         if data_store.config['sonidos']: data_store.config['sonidos'] = False
         else: data_store.config['sonidos'] = True
-        reader.leer_auto(_("sonidos activados.") if data_store.config['sonidos'] else _("sonidos desactivados."))
+        reader.leer_aviso(_("sonidos activados.") if data_store.config['sonidos'] else _("sonidos desactivados."))

--- a/controller/chat_dialog_controller.py
+++ b/controller/chat_dialog_controller.py
@@ -164,7 +164,7 @@ class ChatDialogController:
         if self.active_chat_session and self.active_chat_session.ui:
             self.active_chat_session.ui.treebook.SetFocus()
         
-        reader.leer_auto(self.view.notebook.GetPageText(next_selection))
+        reader.leer_interfaz(self.view.notebook.GetPageText(next_selection))
 
     def previous_session(self):
         page_count = self.view.notebook.GetPageCount()
@@ -179,7 +179,7 @@ class ChatDialogController:
         if self.active_chat_session and self.active_chat_session.ui:
             self.active_chat_session.ui.treebook.SetFocus()
 
-        reader.leer_auto(self.view.notebook.GetPageText(next_selection))
+        reader.leer_interfaz(self.view.notebook.GetPageText(next_selection))
 
     def on_media_player_state_change(self, media_controller, state):
         if state == 'playing':

--- a/controller/kokoro_downloader_controller.py
+++ b/controller/kokoro_downloader_controller.py
@@ -102,7 +102,7 @@ class KokoroDownloaderController:
         self.cancelacion_pedida = True
         self.manager.cancelar()
         self.view.set_status(_("Cancelando la descarga..."))
-        # Con _leer (voz secundaria) y no leer_auto: la voz principal puede ser
+        # Con _leer (voz secundaria) y no leer_aviso: la voz principal puede ser
         # justamente el Kokoro aún sin instalar, es decir, muda.
         reader._leer.speak(_("Cancelando la descarga..."))
         return False

--- a/controller/menus/chat_item_controller.py
+++ b/controller/menus/chat_item_controller.py
@@ -68,6 +68,6 @@ class ChatItemController:
             mensajes_destacados.append({'mensaje': mensaje, 'titulo': titulo})
             
             escribirJsonLista(MENSAJES_DESTACADOS_FILE, mensajes_destacados)
-            reader.leer_sapi(_("El mensaje ha sido archivado correctamente."))
+            reader.leer_aviso(_("El mensaje ha sido archivado correctamente."))
         else: 
-            reader.leer_sapi(_("Este mensaje ya está en la lista de archivados."))
+            reader.leer_aviso(_("Este mensaje ya está en la lista de archivados."))

--- a/helpers/reader_handler.py
+++ b/helpers/reader_handler.py
@@ -120,36 +120,57 @@ class ReaderHandler:
     def set_sapi(self, sapi):
         config['sapi'] = sapi
 
+    def _voz_del_chat(self):
+        """La voz que dice el chat: la voz SAPI 5 secundaria con la casilla
+        «Usar voz sapi» marcada, y el motor elegido cuando no lo está.
+        """
+        return self._leer if config['sapi'] else self._lector
+
     def leer_mensaje(self, mensaje):
         """El chat: los mensajes y los eventos del directo.
 
-        Con la casilla «Usar voz sapi» marcada salen por la voz SAPI 5
-        secundaria y por ahí solamente, tenga el usuario el motor que tenga.
-        Eso es justo lo que la casilla ofrece: una segunda voz que lee el chat
-        mientras el lector de pantalla sigue libre para moverse por el
-        programa. Habla con _leer directamente y no llamando a leer_sapi()
-        porque ese otro camino lleva los avisos del programa, donde la
-        excepción de piper/kokoro/edge sí tiene sentido (ver leer_sapi).
+        Con la casilla marcada salen por la voz SAPI 5 secundaria y por ahí
+        solamente, tenga el usuario el motor que tenga. Eso es justo lo que la
+        casilla ofrece: una segunda voz que lee el chat mientras el lector de
+        pantalla sigue libre para moverse por el programa.
         """
-        if config['sapi']:
-            self._leer.speak(mensaje)
-        else:
-            self.leer_auto(mensaje)
+        self._voz_del_chat().speak(mensaje)
 
-    def leer_sapi(self, mensaje):
-        """Avisos del programa: «Ingresando al chat», errores de conexión…
+    def leer_aviso(self, mensaje):
+        """Los avisos del programa: «Ingresando al chat», los errores de
+        conexión, «Mensaje copiado», «Página borrada»…
 
-        Salen por el motor que lee el programa cuando ese motor tiene voz
-        propia, y caen en la voz SAPI secundaria con auto, sapi5 y onecore —o
-        sea también con la casilla marcada, que devuelve el programa al lector
-        de pantalla y no le deja voz propia (ver motor_de_interfaz).
+        Salen por la misma voz que el chat, y nunca por el lector de pantalla.
+        Lo decidió César: oír «Ingresando al chat» en la voz del motor le
+        confirma al usuario que el motor que eligió en los Ajustes funciona; y
+        una frase corta dicha por el lector de pantalla «se pasa súper rápido»,
+        porque el siguiente evento de foco la corta y uno se la pierde.
+
+        Tiene nombre propio aunque hoy comparta regla con leer_mensaje: son dos
+        familias distintas, y así cada llamada dice a cuál pertenece.
         """
-        if motor_de_interfaz() in ("piper", "kokoro", "edge"):
-            self.leer_auto(mensaje)
-        else:
-            self._leer.speak(mensaje)
+        self._voz_del_chat().speak(mensaje)
 
-    def leer_auto(self, mensaje):
+    def leer_interfaz(self, mensaje):
+        """Moverse por el programa: las flechas en la lista de mensajes, Inicio
+        y Fin, cambiar de pestaña.
+
+        Va por el lector que lee el programa, que con la casilla marcada es el
+        lector de pantalla. Es la voz que sigue el ritmo del teclado cuando uno
+        recorre la lista deprisa, que es de lo que se trata.
+        """
+        self._lector.speak(mensaje)
+
+    def leer_motor(self, mensaje):
+        """Las pruebas del motor: las frases que solo significan algo dichas
+        por el motor elegido, como «Hablaré a través de este dispositivo».
+
+        Hoy hace lo mismo que leer_interfaz, porque las dos hablan con el
+        lector que está cargado, pero no son lo mismo: con la casilla marcada
+        no hay ningún motor cargado y estas frases mentirían en boca del lector
+        de pantalla. Por eso quien llama mira antes motor_de_interfaz() y no
+        llega hasta aquí en ese caso.
+        """
         self._lector.speak(mensaje)
 
     def silence(self):

--- a/players/media_handler.py
+++ b/players/media_handler.py
@@ -21,14 +21,14 @@ class MediaHandler:
             print("Error: No se ha proporcionado ninguna URL.")
             return
         if self.cargando:
-            reader.leer_auto("ya está cargando un reproductor")
+            reader.leer_aviso("ya está cargando un reproductor")
             return
         if self.sonando and self.player and self.player.is_playing(): # Already playing
             self._notify_state_change('playing') # Re-confirm playing state
             return
 
         self.cargando = True
-        reader.leer_auto("Cargando el reproductor")
+        reader.leer_aviso("Cargando el reproductor")
         self._notify_state_change('loading')
 
         def playback_task():

--- a/servicios/YouTubeRealDataTime.py
+++ b/servicios/YouTubeRealDataTime.py
@@ -35,7 +35,7 @@ class YouTubeRealTimeService:
         threading.Thread(target=self.prepare, daemon=True).start()
         self._hilo = threading.Thread(target=self.recibir, daemon=True)
         self._hilo.start()
-        wx.CallAfter(reader.leer_sapi, "Cambiando a servicio de tiempo real.")
+        wx.CallAfter(reader.leer_aviso, "Cambiando a servicio de tiempo real.")
 
     def detener(self):
         if self.chat:

--- a/servicios/discord.py
+++ b/servicios/discord.py
@@ -56,7 +56,7 @@ class ServicioDiscord:
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
         try:
-            wx.CallAfter(reader.leer_sapi, _("Cargando..."))
+            wx.CallAfter(reader.leer_aviso, _("Cargando..."))
             if data_store.dst: self.translator = translator.TranslatorWrapper()
 
             intents = discord.Intents.default()
@@ -107,7 +107,7 @@ class ServicioDiscord:
         self.client.event(self.on_message)
 
     async def on_ready(self):
-        wx.CallAfter(reader.leer_sapi, _("Ingresando al chat"))
+        wx.CallAfter(reader.leer_aviso, _("Ingresando al chat"))
         if data_store.config['sonidos'] and data_store.config['listasonidos'][6]:
             wx.CallAfter(player.play, rutasonidos[6])
         try:
@@ -119,7 +119,7 @@ class ServicioDiscord:
             wx.CallAfter(self.chat_controller.chat_dialog.update_chat_page_title, self.chat_controller, title)
         except Exception:
             logger.exception("Error al acceder al canal de Discord")
-            wx.CallAfter(reader.leer_sapi, _("No se encontró el canal de Discord. Comprueba que el bot está invitado al servidor y que el enlace del canal es correcto."))
+            wx.CallAfter(reader.leer_aviso, _("No se encontró el canal de Discord. Comprueba que el bot está invitado al servidor y que el enlace del canal es correcto."))
             self.detener()
 
     async def on_message(self, message):

--- a/servicios/kick.py
+++ b/servicios/kick.py
@@ -40,7 +40,7 @@ class ServicioKick:
 
         if not os.path.exists(bypass_executable):
             logger.error("No se encuentra el archivo '%s'.", bypass_executable)
-            wx.CallAfter(reader.leer_sapi, _("error_bypass_no_encontrado"))
+            wx.CallAfter(reader.leer_aviso, _("error_bypass_no_encontrado"))
             return False
 
         creation_flags = subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0
@@ -70,10 +70,10 @@ class ServicioKick:
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
         try:
-            wx.CallAfter(reader.leer_sapi, _("Cargando..."))
+            wx.CallAfter(reader.leer_aviso, _("Cargando..."))
             if not self._run_bypass_and_wait():
                 if self.is_running:
-                    wx.CallAfter(reader.leer_sapi, _("error_iniciar_bypass"))
+                    wx.CallAfter(reader.leer_aviso, _("error_iniciar_bypass"))
                 self.detener()
                 return
 
@@ -100,7 +100,7 @@ class ServicioKick:
         self.client.event(self.on_follow)
 
     async def on_ready(self):
-        wx.CallAfter(reader.leer_sapi, _("Ingresando al chat"))
+        wx.CallAfter(reader.leer_aviso, _("Ingresando al chat"))
         if data_store.config['sonidos'] and data_store.config['listasonidos'][6]:
             wx.CallAfter(player.play, rutasonidos[6])
         try:
@@ -118,7 +118,7 @@ class ServicioKick:
                 self.chat_controller.set_media_controller(self.media_controller)
         except Exception:
             logger.exception("Error al conectar al chatroom de Kick")
-            wx.CallAfter(reader.leer_sapi, _("error_conectar_kick_chatroom"))
+            wx.CallAfter(reader.leer_aviso, _("error_conectar_kick_chatroom"))
             self.detener()
 
     async def on_message(self, message: kick.Message):

--- a/servicios/sala.py
+++ b/servicios/sala.py
@@ -33,7 +33,7 @@ class ServicioSala:
             self._hilo.daemon = True
             self._hilo.start()
             player.play(rutasonidos[6])
-            reader.leer_sapi(_("Ingresando al chat."))
+            reader.leer_aviso(_("Ingresando al chat."))
             title = _("Chat de la sala de juegos")
             wx.CallAfter(self.chat_controller.agregar_titulo, title)
             wx.CallAfter(self.chat_controller.chat_dialog.update_chat_page_title, self.chat_controller, title)

--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -102,7 +102,7 @@ class ServicioTiktok:
                 is_live_now = await self.chat.is_live()
                 if is_live_now:
                     if self.last_live_status is not True:
-                        wx.CallAfter(reader.leer_sapi, _("El usuario está en vivo. Conectando..."))
+                        wx.CallAfter(reader.leer_aviso, _("El usuario está en vivo. Conectando..."))
                     self.last_live_status = True
                     if data_store.dst: self.translator = translator.TranslatorWrapper()
                     # Casilla «Leer los mensajes anteriores al chat» desmarcada: se ignoran los
@@ -113,7 +113,7 @@ class ServicioTiktok:
                     await self.chat.connect()
                 else:
                     if self.last_live_status is not False:
-                        wx.CallAfter(reader.leer_sapi, _("El usuario no está en vivo. Reintentando en un minuto."))
+                        wx.CallAfter(reader.leer_aviso, _("El usuario no está en vivo. Reintentando en un minuto."))
                     self.last_live_status = False
                     if self.is_running: await asyncio.sleep(60)
             except asyncio.CancelledError:
@@ -185,7 +185,7 @@ class ServicioTiktok:
 
     async def finalizado(self, event: LiveEndEvent):
         self.last_live_status = False
-        wx.CallAfter(reader.leer_sapi, _("El directo ha finalizado. Se buscará de nuevo en un minuto."))
+        wx.CallAfter(reader.leer_aviso, _("El directo ha finalizado. Se buscará de nuevo en un minuto."))
 
     async def on_disconnect(self, event: DisconnectEvent):
         # TikTokLive emite DisconnectEvent en cada cierre del websocket, incluido el fin
@@ -193,11 +193,11 @@ class ServicioTiktok:
         # así que dejamos que el bucle de _run_client_async siga sondeando cada minuto.
         if self.is_running and self.last_live_status is not False:
             self.is_running = False
-            wx.CallAfter(reader.leer_sapi, _("Se ha perdido la conexión. El servicio se ha detenido."))
+            wx.CallAfter(reader.leer_aviso, _("Se ha perdido la conexión. El servicio se ha detenido."))
 
     async def on_connect(self,event: ConnectEvent):
         self.last_live_status = True
-        wx.CallAfter(reader.leer_sapi, _("Ingresando al chat"))
+        wx.CallAfter(reader.leer_aviso, _("Ingresando al chat"))
         if not self.media_controller:
             threading.Thread(target=self.prepare_player, daemon=True).start()
         if data_store.config['sonidos'] and data_store.config['listasonidos'][6]:

--- a/servicios/twich.py
+++ b/servicios/twich.py
@@ -30,7 +30,7 @@ class ServicioTwich:
         self._hilo = threading.Thread(target=self.recibir, daemon=True)
         self._hilo.start()
         player.play(rutasonidos[6])
-        reader.leer_sapi(_("Ingresando al chat."))
+        reader.leer_aviso(_("Ingresando al chat."))
 
     def detener(self):
         self._detener = True

--- a/servicios/youtube.py
+++ b/servicios/youtube.py
@@ -31,7 +31,7 @@ class ServicioYouTube:
         self._hilo = threading.Thread(target=self.recibir, daemon=True)
         self._hilo.start()
         player.play(rutasonidos[6])
-        reader.leer_sapi(_("Ingresando al chat."))
+        reader.leer_aviso(_("Ingresando al chat."))
 
     def detener(self):
         self._detener = True

--- a/utils/app_utilitys.py
+++ b/utils/app_utilitys.py
@@ -53,7 +53,7 @@ def configurar_piper(parent, carpeta_voces):
                 lista_voces_piper.extend(piper_list_voices())
                 config['voz'] = 0
                 _cargar_voz_piper_actual()
-                reader.leer_auto(_("Lector Piper inicializado correctamente."))
+                reader.leer_motor(_("Lector Piper inicializado correctamente."))
     elif isinstance(onnx_models, str) or isinstance(onnx_models, list):
         # Solo se recoloca la voz si el índice guardado quedó fuera de rango:
         # resetearla siempre hacía perder la voz elegida en cada Aceptar.


### PR DESCRIPTION
Esto es lo que hablamos por privado: las tres funciones, ahora que está claro quién tiene que leer cada cosa. Es independiente de la #120, no tocan los mismos ficheros.

## El problema

El lector tenía tres funciones cuyos nombres decían el cómo y no el qué: `leer_mensaje`, `leer_sapi` y `leer_auto`. Las dos últimas se repartían dos familias que no tienen nada que ver, y `leer_auto` llevaba además una tercera de matute. Eso se oía: la misma acción sonaba por voces distintas según por dónde se hubiera pedido.

## Cuatro nombres para tres reglas

- **`leer_mensaje`** — el chat. Sin cambios.
- **`leer_aviso`** — los avisos del programa: «Ingresando al chat», los errores de conexión, «Mensaje copiado», «Página borrada». Salen por la misma voz que el chat y **nunca por el lector de pantalla**, como pediste: oír «Ingresando al chat» en la voz del motor confirma que el motor elegido en los Ajustes funciona, y una frase corta dicha por el lector de pantalla se pasa súper rápido, porque el siguiente evento de foco la corta.
- **`leer_interfaz`** — moverse por el programa: las flechas en la lista, Inicio y Fin, cambiar de pestaña. Va por el lector principal, que con la casilla marcada es el lector de pantalla. Es la voz que sigue el ritmo del teclado, que es de lo que se trataba.
- **`leer_motor`** — las pruebas: «Hablaré a través de este dispositivo», que solo significan algo dichas por el motor.

`leer_aviso` comparte hoy la regla de `leer_mensaje` y aun así tiene nombre propio: son dos familias distintas, y así cada llamada dice a cuál pertenece en vez de dejarlo a la memoria del que lea. Lo mismo entre `leer_interfaz` y `leer_motor`, que hablan las dos con el lector cargado por motivos que no son el mismo.

`leer_auto` y `leer_sapi` desaparecen; son cincuenta llamadas reencaminadas.

## Lo que cambia al oído

1. **Archivar un mensaje suena igual por los dos caminos.** La confirmación salía por `leer_auto` desde el atajo y por `leer_sapi` desde el menú contextual: con la casilla marcada, la misma acción se decía unas veces por el lector de pantalla y otras por la voz SAPI. Esto es lo del atajo que comentabas.
2. **Con la casilla marcada, las confirmaciones del chat pasan del lector de pantalla a la voz que lee el chat**: «Mensaje copiado», «Mensaje agregado a favoritos», «Página borrada», la lectura automática y los sonidos.
3. **Con auto, onecore o sapi5 elegidos y la casilla SIN marcar, los avisos de conexión pasan de la voz SAPI secundaria al motor elegido.** Antes `leer_sapi` los mandaba a la voz secundaria siempre que el motor no fuera piper, kokoro ni edge; ahora siguen al motor, sea cual sea.

Con piper, kokoro o edge elegidos, los avisos de los servicios **no se mueven**: salían por el motor y siguen saliendo por el motor.

## Lo que no se toca

Las llamadas directas a `_leer` que apuntan a la voz SAPI a propósito —el descargador de Kokoro, el arranque, varios sitios de los Ajustes— se quedan como están. Y las tres cadenas que están fuera de `_()` que se ven de paso (`players/media_handler.py` y `servicios/YouTubeRealDataTime.py`) van con el lote de i18n, no aquí.

## Comprobado

- Banco reescrito sobre el reparto nuevo: las cuatro funciones con los seis motores y la casilla en las dos posiciones, más dos lecturas del código —que no quede ni un `leer_auto` ni un `leer_sapi`, y que los dos caminos de archivar llamen a la misma función—.
- Probado con NVDA: los avisos de conexión y las confirmaciones por la voz SAPI, las flechas y las pestañas por NVDA, y archivar suena igual por el atajo y por el menú contextual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)