### PR TITLE
Seis except con sintaxis de Python 2 impedían arrancar canary

### DIFF
--- a/TTS/sherpa_handler.py
+++ b/TTS/sherpa_handler.py
@@ -329,7 +329,7 @@ class sherpaSpeak:
                     ruta = proc.info.get("exe")
                     if ruta and os.path.normcase(ruta) == ruta_propia:
                         proc.kill()
-                except psutil.NoSuchProcess, psutil.AccessDenied:
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
         except:
             pass

--- a/TTS/sonata_handler.py
+++ b/TTS/sonata_handler.py
@@ -200,7 +200,7 @@ class piperSpeak:
                     ruta = proc.info.get("exe")
                     if ruta and os.path.normcase(ruta) == ruta_propia:
                         proc.kill()
-                except psutil.NoSuchProcess, psutil.AccessDenied:
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
         except:
             pass

--- a/update/bootstrap.py
+++ b/update/bootstrap.py
@@ -29,7 +29,7 @@ def _is_process_running(name: str) -> bool:
             timeout=5,
         )
         return name.lower() in result.stdout.lower()
-    except subprocess.SubprocessError, OSError:
+    except (subprocess.SubprocessError, OSError):
         logger.debug("Failed to check process '%s'", name, exc_info=True)
         return False
 

--- a/update/github_client.py
+++ b/update/github_client.py
@@ -133,7 +133,7 @@ def _parse_release(release: dict) -> ReleaseInfo | None:
     version = tag[1:] if tag[:1].lower() == "v" else tag
     try:
         Version(version)
-    except InvalidVersion, TypeError:
+    except (InvalidVersion, TypeError):
         logger.debug("Release '%s' has an invalid semantic version, skipping", tag)
         return None
 
@@ -262,7 +262,7 @@ def _select_highest_release(releases: list[dict]) -> ReleaseInfo | None:
             continue
         try:
             candidates.append((Version(info.version), info))
-        except InvalidVersion, TypeError:
+        except (InvalidVersion, TypeError):
             continue
     return (
         max(candidates, key=lambda candidate: candidate[0])[1] if candidates else None

--- a/utils/funciones.py
+++ b/utils/funciones.py
@@ -34,7 +34,7 @@ def leerJsonLista(arch):
         try:
             with open(arch) as file:
                 return json.load(file)
-        except json.JSONDecodeError, ValueError, OSError:
+        except (json.JSONDecodeError, ValueError, OSError):
             return []
     else:
         return []


### PR DESCRIPTION
## Qué pasaba

Los commits `fe9fb0e` y `ee4fb03` traen seis `except A, B:` — la sintaxis de Python 2. En Python 3 es un **SyntaxError al importar**, así que el módulo entero deja de cargar:

- `utils/funciones.py:37` — lo importa medio programa
- `update/github_client.py:136` y `:265` — `run_main_window.py` lo importa en la línea 16, **por eso la app no arrancaba**
- `update/bootstrap.py:32`
- `TTS/sonata_handler.py:203` y `TTS/sherpa_handler.py:332` — los dos puentes de voz, o sea ni Piper ni Kokoro

(Hay un séptimo en `helpers/keyboard_handler/linux.py:24`, pero ese es viejo y nunca se importa en Windows; no lo toco.)

## El arreglo

Solo los paréntesis: `except A, B:` → `except (A, B):`. Seis líneas, ningún cambio de comportamiento.

## Verificado

- `compileall` sobre el árbol entero: limpio.
- `import update.update`, `import utils.funciones`, `import TTS.lector`: pasan.
- Los **135 tests de `tests/test_updater`: en verde**. (Antes del arreglo ni siquiera podían importarse — por eso no saltaron en el push.)

De paso: con esto ya compila la validación de versión que añadió `ee4fb03`, y la comprobé con una lista fabricada — una release con tag no numérico (tipo «motores») ahora se ignora aunque traiga `.zip` + `.sha256`. Justo lo que hablábamos ayer de la etiqueta fija para los motores: con este fix, ese camino queda libre de peligro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)