### PR TITLE
Las listas anuncian su nombre: wx.Accessible en vez del SetName() que los lectores ignoran

### DIFF
--- a/ui/ajustes/categorias.py
+++ b/ui/ajustes/categorias.py
@@ -2,6 +2,7 @@ import wx
 
 from globals.data_store import config
 from globals.mensajes import mensajes_categorias
+from utils.menu_accesible import AccesibleConNombre
 
 
 class PanelCategorias(wx.Panel):
@@ -9,6 +10,7 @@ class PanelCategorias(wx.Panel):
         super().__init__(parent, wx.ID_ANY)
         sizer_categoriza = wx.BoxSizer(wx.VERTICAL)
         self.categoriza = wx.ListCtrl(self, wx.ID_ANY, style=wx.LC_REPORT)
+        self.categoriza.SetAccessible(AccesibleConNombre(_("Categorías")))
         self.categoriza.InsertColumn(0, _("Categoría"))
         self.categoriza.EnableCheckBoxes()
         sizer_categoriza.Add(self.categoriza, 1, wx.EXPAND | wx.ALL, 5)

--- a/ui/ajustes/sonidos.py
+++ b/ui/ajustes/sonidos.py
@@ -4,6 +4,7 @@ from globals.data_store import config
 from globals.mensajes import mensajes_sonidos
 from globals.resources import listar_temas_sonidos, recargar_rutasonidos
 from setup import player
+from utils.menu_accesible import AccesibleConNombre
 
 
 class PanelSonidos(wx.Panel):
@@ -25,6 +26,9 @@ class PanelSonidos(wx.Panel):
             recargar_rutasonidos()
         sizer_soniditos.Add(self.lista_temas, 0, wx.EXPAND | wx.ALL, 5)
         self.soniditos = wx.ListCtrl(self, wx.ID_ANY, style=wx.LC_REPORT)
+        # Sin esto el lector de pantalla toma el StaticText anterior
+        # ("Tema de sonidos") como nombre de la lista
+        self.soniditos.SetAccessible(AccesibleConNombre(_("Sonidos")))
         self.soniditos.InsertColumn(0, _("Sonido"))
         self.soniditos.EnableCheckBoxes()
         sizer_soniditos.Add(self.soniditos, 1, wx.EXPAND | wx.ALL, 5)

--- a/ui/chat_ui.py
+++ b/ui/chat_ui.py
@@ -1,7 +1,7 @@
 import wx
 
 from globals import data_store
-from utils.menu_accesible import Accesible
+from utils.menu_accesible import Accesible, AccesibleConNombre
 
 
 class ChatPanel(wx.Panel):
@@ -94,10 +94,9 @@ class ChatPanel(wx.Panel):
 
     def create_page_with_listbox(self, parent, name, plataforma=None):
         page = wx.Panel(parent)
-        page.SetName(str(name))
         sizer = wx.BoxSizer(wx.VERTICAL)
         list_box = wx.ListBox(page, wx.ID_ANY)
-        list_box.SetName(str(name))
+        list_box.SetAccessible(AccesibleConNombre(str(name)))
         sizer.Add(list_box, 1, wx.EXPAND | wx.ALL, 5)
         if plataforma == "TikTok" and name == _("Eventos"):
             self.boton_filtrar = wx.Button(page, wx.ID_ANY, _("&Filtrar por"))

--- a/utils/menu_accesible.py
+++ b/utils/menu_accesible.py
@@ -18,3 +18,18 @@ class Accesible(wx.Accessible):
 
     def GetDefaultAction(self, childId):
         return (wx.ACC_OK, "Abrir menú")
+
+
+class AccesibleConNombre(wx.Accessible):
+    """Da un nombre accesible a un control que no puede tomarlo de un
+    wx.StaticText anterior. wx.Window.SetName() no sirve para esto: solo
+    alimenta FindWindowByName(), los lectores de pantalla lo ignoran."""
+
+    def __init__(self, nombre):
+        wx.Accessible.__init__(self)
+        self.nombre = nombre
+
+    def GetName(self, childId):
+        if childId == 0:
+            return (wx.ACC_OK, self.nombre)
+        return (wx.ACC_NOT_IMPLEMENTED, "")


### PR DESCRIPTION
## Qué pasaba

`wx.Window.SetName()` no crea un nombre accesible: solo alimenta `FindWindowByName()`, y los lectores de pantalla lo ignoran por completo. Lo verificamos con NVDA el 21-08 sobre las listas del chat: al tabular, NVDA decía «lista» a secas, sin nombre. Eso significa que el arreglo n.º 3 de la PR #80 (los `SetName` de `create_page_with_listbox`) nunca tuvo el efecto que buscaba — lo digo con honestidad porque esa PR fue mía.

Había dos víctimas más en Configuración, encontradas por revisión de accesibilidad:

- La lista de sonidos heredaba como nombre el `wx.StaticText` anterior, «Tema de sonidos» — el label del selector de temas, no el suyo.
- La lista de categorías no tenía nombre ninguno.

## Qué cambia

Nueva clase `AccesibleConNombre` en `utils/menu_accesible.py` (al lado de `Accesible`, mismo patrón que ya usamos en el botón Opciones y en el botón de instalar voces): un `wx.Accessible` que **solo** sobrecarga `GetName` para `childId` 0 y responde `ACC_NOT_IMPLEMENTED` para todo lo demás, de modo que los elementos de las listas, sus estados y las casillas siguen llegando por el proxy nativo.

- `ui/chat_ui.py`: las listas del chat anuncian su nombre real («General», «Eventos», «Favoritos»…). Fuera los dos `SetName` sin efecto (no hay ningún `FindWindowByName` en el árbol, verificado por grep).
- `ui/ajustes/sonidos.py`: la lista anuncia «Sonidos», ya no roba «Tema de sonidos».
- `ui/ajustes/categorias.py`: la lista anuncia «Categorías».
- `ui/ajustes/eventos.py` no se toca: sus dos listas ya tienen su `StaticText` delante y funcionan bien.

**Cero cadenas nuevas**: «Sonidos» y «Categorías» ya existen en los siete catálogos (son los títulos de las pestañas), así que no hay trabajo de traducción.

## Verificación

- Probado con NVDA por Enzo antes de abrir la PR: las listas del chat y de Configuración anuncian su nombre al tabular, los mensajes se leen igual al flechar, y las casillas de las listas de sonidos y categorías siguen anunciando marcado/desmarcado con Espacio. La pestaña Eventos (no tocada) se comporta igual que antes.
- `compileall` limpio sobre todo el árbol; diff de +23/−3 en 4 archivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)