### PR TITLE
Rollback temporal: updater.json vuelve a 3.94

### DIFF
--- a/updater.json
+++ b/updater.json
@@ -1,7 +1,7 @@
 {
-    "current_version": "3.95",
-    "description": "VeTube 3.95: la app arranca sin tarjeta de sonido, actualizador nuevo, motores de voz Piper/Kokoro/Edge y decenas de correcciones.",
+    "current_version": "3.94",
+    "description": "actualizar para leer en vivos de tiktok.",
     "downloads": {
-        "Windows64": "https://github.com/metalalchemist/VeTube/releases/download/v3.95/vetube-v3.95-transicion.zip"
+        "Windows64": "https://github.com/metalalchemist/VeTube/releases/latest/download/VeTube-x64.zip"
     }
 }


### PR DESCRIPTION
La 3.95 se retira de circulación esta noche (decisión de Enzo): el incidente de los accesos directos ya está corregido en el paquete (lanzador), pero preferimos re-probar la cadena completa con calma en una sesión nueva antes de dejarla al aire. Con esto ninguna 3.94 ve la actualización. La release v3.95 pasa a pre-release en paralelo (latest vuelve a v3.94). Reactivación: revertir este commit + quitar el pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)