### PR TITLE
build: el motor sonata sale del paquete (64/ se enumera archivo por archivo)

### DIFF
--- a/TTS/sonata_handler.py
+++ b/TTS/sonata_handler.py
@@ -69,8 +69,10 @@ _BIN_DESCARGADO = ENGINES_DIR / "sonata"
 
 
 def sonata_bin_dir():
-    """Carpeta del servidor sonata. El empaquetado (64/sonata) manda si está:
-    viaja con el build, así que siempre es de la misma versión que la app. El
+    """Carpeta del servidor sonata. El empaquetado (64/sonata) manda si está,
+    pero desde la 3.95 ya no viaja en el build: donde queda es en el árbol de
+    desarrollo y en las instalaciones anteriores, así que es de la versión de
+    la app que lo trajo, no forzosamente de la que está corriendo. El
     descargado (engines/sonata) es para las instalaciones que ya no lo traen."""
     if (_BIN_EMPAQUETADO / NOMBRE_EXE_SONATA).is_file():
         return _BIN_EMPAQUETADO

--- a/TTS/sonata_handler.py
+++ b/TTS/sonata_handler.py
@@ -55,7 +55,11 @@ _ORFANOS_LIMPIADOS = False
 
 NOMBRE_EXE_SONATA = "sonata-grpc.exe"
 # Carpeta clásica, resuelta respecto a este módulo: en la app compilada cae en
-# lib/64/sonata, y funciona porque el build copia 64/ también a lib/64/.
+# lib/64/sonata. Desde la 3.95 el build YA NO la copia (pyproject enumera 64/
+# archivo por archivo y deja sonata fuera), así que solo existe en dos sitios:
+# el árbol de desarrollo, y las instalaciones anteriores a la 3.95, donde
+# quedó del build viejo (el actualizador no borra nada). En ambos casos manda,
+# porque es de la misma versión que la app que la trajo.
 _BIN_EMPAQUETADO = (
     Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) / "64" / "sonata"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vetube"
-version = "3.95-rc4"
+version = "3.95"
 description = "Aplicación VeTube"
 readme = "README.md"
 requires-python = ">=3.14"
@@ -168,7 +168,16 @@ include_files = [
     ["locales/", "locales/"],
     ["sounds/", "sounds/"],
 
-    ["64/", "lib/64/"], # bypass64.exe, VLC, Sonata TTS
+    # OJO: el contenido de 64/ va enumerado UNO POR UNO, a propósito. El motor
+    # sonata (64/sonata, unos 48 MB) ya no viaja en el build: se descarga a
+    # demanda desde la release «motores». Como la carpeta ya no se copia
+    # entera, TODO lo que se añada dentro de 64/ hay que apuntarlo también
+    # aquí, o no llegará al build sin dar el menor aviso.
+    ["64/bypass64.exe", "lib/64/bypass64.exe"],
+    ["64/libvlc.dll", "lib/64/libvlc.dll"],
+    ["64/libvlccore.dll", "lib/64/libvlccore.dll"],
+    ["64/plugins/", "lib/64/plugins/"], # VLC
+    ["64/sherpa/", "lib/64/sherpa/"], # motor Kokoro
 
     [".venv/Lib/site-packages/sound_lib/lib/", "sound_lib/lib/"],
 ]


### PR DESCRIPTION
## Qué pasa

La [#133](https://github.com/metalalchemist/VeTube/pull/133) añadió el descargador del motor sonata, pero le falta esta mitad: mientras `pyproject.toml` copie `64/` entera al build, el motor sigue viajando dentro de la app y **el descargador no lo usa nadie**, porque `sonata_bin_dir()` da preferencia al empaquetado. Los 48 MB seguirían ahí y el trabajo de la #133 quedaría dormido.

## Qué cambia

`include_files` ya no puede llevar la carpeta de golpe, así que enumera lo que sí debe viajar:

- `64/bypass64.exe`
- `64/libvlc.dll`
- `64/libvlccore.dll`
- `64/plugins/` (VLC)
- `64/sherpa/` (motor de Kokoro — se queda dentro, todavía no tiene descargador)

Fuera queda `64/sonata`, que a partir de ahora se descarga a demanda desde la release «motores».

También `version = "3.95"` en vez de `"3.95-rc4"`. En un build lanzado por tag la CI toma el número del tag y este campo no se usa, pero preferimos que no mienta.

## La deuda que esto crea (avisada en el propio archivo)

Al perder el `["64/", "lib/64/"]` de golpe, **todo lo que se añada dentro de `64/` en el futuro hay que apuntarlo también en esa lista, o no llegará al build sin dar el menor aviso**. Dejo un comentario en español encima de la lista para que quien pase por ahí lo vea.

## Qué NO cambia, a propósito

Las instalaciones anteriores a la 3.95 conservan su `64/sonata` en el disco (el actualizador no borra nada) y lo seguirán usando, porque el empaquetado manda. Es deliberado: borrarlo obligaría a cada usuario que ya funciona a descargar 20 MB en el primer arranque, y si en ese momento no tiene red se quedaría con el respaldo SAPI, es decir con una voz distinta sin haber pedido nada. Preferimos dejar el resto ahí. Actualizo el comentario de `TTS/sonata_handler.py`, que decía que el build copia `64/` y ya no es verdad.

## Verificación

- El TOML sigue siendo válido y **las diez rutas listadas existen en el árbol** (comprobado con `tomllib` recorriendo `include_files`).
- `compileall` limpio en todo el árbol.
- El tamaño final del `.msi` solo lo puede decir el build de la CI. Sin comprimir son unos 48 MB menos, sobre un `64/` de unos 184 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
