### PR TITLE
chore: uv.lock al día con la versión 3.95 (el build de master fallaba con --locked)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1770,7 +1770,7 @@ wheels = [
 
 [[package]]
 name = "vetube"
-version = "3.95rc4"
+version = "3.95"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
## Qué pasa

El build de control de master (run 34392256579, tras el avance rápido canary→master de hoy) falla en «Install dependencies»: uv sync --locked rechaza el lockfile porque uv.lock sigue diciendo vetube 3.95rc4 mientras pyproject.toml dice 3.95 desde la #134. Con --locked, cualquier tag (rc7 o v3.95) fallaría igual.

## Qué cambia

Una sola línea de uv.lock: la versión del paquete vetube pasa de 3.95rc4 a 3.95. Es exactamente el mismo gesto que los commits de Rowell 6443678 («chore: update uv.lock for version 3.95-rc4», 1 línea) y e8634e2 (rc2): uv lock no cambia nada más en un bump de versión. Ninguna dependencia se toca.

## Verificación

- uv.lock no había cambiado en ninguno de los 11 commits que entraron hoy en master (git diff 160521a e192f51 -- uv.lock vacío); el único cambio relevante era la versión en pyproject.toml.
- La prueba real es el build de master al fusionar (release.yml corre en cada push a master): debe volver a verde antes de poner el tag v3.95-rc7.
- Base master porque la release está en marcha; canary se pondrá al día con un avance rápido al final (hoy master y canary eran idénticos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
