### PR TITLE
release(3.96): updater.json apunta a la 3.96 con el paquete de transición para las ≤ 3.94

### DIFF
--- a/updater.json
+++ b/updater.json
@@ -1,7 +1,7 @@
 {
-    "current_version": "3.94",
-    "description": "actualizar para leer en vivos de tiktok.",
+    "current_version": "3.96",
+    "description": "Versión 3.96: actualizador renovado, motores de voz Piper y Kokoro descargables a demanda (instalación más ligera), idioma ruso completo, TikTok actualizado y varias correcciones.",
     "downloads": {
-        "Windows64": "https://github.com/metalalchemist/VeTube/releases/latest/download/VeTube-x64.zip"
+        "Windows64": "https://github.com/metalalchemist/VeTube/releases/download/v3.96/vetube-v3.96-transicion.zip"
     }
 }


### PR DESCRIPTION
## Qué cambia

`updater.json` (el canal de las instalaciones ≤ 3.94, URL en duro en esos exe) pasa a anunciar la **3.96** con un enlace **directo y versionado** al paquete de transición:

`https://github.com/metalalchemist/VeTube/releases/download/v3.96/vetube-v3.96-transicion.zip`

Es el ÚLTIMO gesto de la release, a propósito: todo lo demás ya está servido por master (zips de `translates/` regenerados en la #138, mismos `locales/` que la 3.96) y por la release v3.96 (zip CI + paquete de transición + `.sha256`).

## Por qué el paquete de transición y no el zip de la CI

Las 3.94 traen el actualizador viejo, que saca `bootstrap.exe` del árbol y lo lanza solo: el bootstrap cx_Freeze de la CI no arranca así (falta `python314.dll`). El paquete de transición es el árbol 3.96 de la CI **tal cual** (mismo zip, mismo SHA-256 de origen), con un `bootstrap.exe` autosuficiente que además instala el bootstrap nuevo para las siguientes actualizaciones, reescribe los accesos directos hacia `VeTube.exe` y limpia los restos de la 3.94. Las instalaciones nuevas y las que ya están en 3.95/3.96 siguen usando el zip normal de la CI a través del actualizador nuevo.

## Verificación

- Zip `vetube-v3.96.zip` descargado y su SHA-256 comprobado contra el `.sha256` de la release antes de emballarlo.
- Paquete `vetube-v3.96-transicion.zip` subido a la release v3.96 con su `.sha256`; enlace comprobado en HTTP 200 antes de abrir esta PR.
- Banco `banc_394_a_395_transicion.py` (ajustado a 3.96) contra el paquete real: **31/31** — cadena completa desde una 3.94 oficial: diálogo, descarga, bootstrap, copia, `data.json` y voces preservados, `locales/` refrescado, accesos directos reescritos, `run_main_window.exe` y `_internal/` retirados, `VeTube.exe` relanzado.
- Contenido del zip 3.96 revisado: `lib/64/` con bypass64 + libvlc + plugins, 7 idiomas en `locales/`, sin motores ni `translates/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
