### PR TITLE
docs: fix GitHub username in contributors

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -79,13 +79,13 @@ Thanks to all the people who have contributed code, bug fixes, and improvements 
         <a href="https://github.com/metalalchemist/VeTube/commits?author=NightPurrer" title="Code">💻</a>
       </td>
       <td align="center" valign="top" width="14.28%">
-        <a href="https://github.com/galorasd">
-          <img src="https://github.com/galorasd.png?s=100" width="100px;" alt="Jesús Pavón Abián"/>
+        <a href="https://github.com/jpavonabian">
+          <img src="https://github.com/jpavonabian.png?s=100" width="100px;" alt="Jesús Pavón Abián"/>
           <br/>
           <sub><b>Jesús Pavón Abián</b></sub>
         </a>
         <br/>
-        <a href="https://github.com/metalalchemist/VeTube/commits?author=galorasd" title="Code">💻</a>
+        <a href="https://github.com/metalalchemist/VeTube/commits?author=jpavonabian" title="Code">💻</a>
       </td>
       <td align="center" valign="top" width="14.28%">
         <a href="https://github.com/MuhammadGagah">


### PR DESCRIPTION
## What does this PR do?

Updates the GitHub username for Jesús Pavón Abián in `contributors.md` from `galorasd` to `jpavonabian` (profile link, avatar and commits link).

## Why is this needed?

The listed username was wrong, so the profile link and avatar pointed to the wrong account.

## How to test

1. Open `contributors.md` on GitHub.
2. Check that the Jesús Pavón Abián card shows the correct avatar and links to https://github.com/jpavonabian.

## Checklist

- [x] Code follows project conventions
- [ ] Tested in development mode (N/A, docs only)
- [ ] Tested compiled build (N/A, docs only)
- [ ] No new warnings in logs (N/A, docs only)
- [x] Documentation updated (if needed)
- [ ] Translations updated (if needed) (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174oxe6mgoFth2fxgD3Qjij
