### PR TITLE
Leer el chat de TikTok desde el navegador (firmador local, alternativa a EulerStream)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ src/vetube.egg-info/
 # Scratch / temp files
 @AutomationLog.txt
 issue-body.md
+
+# Extension: carpeta generada por Chrome al cargarla y salidas de prueba
+interceptor_extension/_metadata/
+ultima_captura.json
+tramas_capturadas.json

--- a/FIRMADOR_LOCAL.md
+++ b/FIRMADOR_LOCAL.md
@@ -1,0 +1,202 @@
+# Firmador local: leer el chat de TikTok desde el navegador
+
+Esta es la documentación del **firmador local**, una forma de leer el chat de los
+directos de TikTok en VeTube **sin depender de ningún servidor de firmas externo**.
+
+Está pensada para leerse de arriba abajo: primero qué problema resuelve, después
+cómo instalarlo y usarlo, y al final cómo funciona por dentro y qué hacer si algo
+no anda.
+
+---
+
+## El problema
+
+Para leer el chat de un directo, TikTok exige que la petición al *websocket* del
+chat vaya **firmada**. La librería que usa VeTube (`TikTokLive`) no calcula esa
+firma: se la pide a un servicio externo, **EulerStream**. Ese servicio:
+
+- se cae seguido (cuando se cae, VeTube no puede leer **ningún** directo de TikTok),
+- comparte un cupo limitado entre todos sus usuarios,
+- es un tercero al que, en algunos modos, habría que entregarle datos de sesión.
+
+No hay una API oficial de chat en vivo de TikTok, así que no se puede evitar la
+firma… **salvo** que la haga el propio navegador.
+
+---
+
+## La idea
+
+Cuando abrís un directo de TikTok en tu navegador, el navegador **ya** hace la
+petición firmada y **ya** recibe el chat: los mensajes le llegan por un websocket.
+El firmador local no reinventa la firma ni manda tu sesión a nadie: simplemente
+**copia los mensajes que tu navegador ya está recibiendo** y se los pasa a VeTube.
+
+En una frase: *VeTube lee por encima del hombro de tu navegador, que es quien
+realmente está conectado a TikTok.*
+
+---
+
+## Cómo funciona (las dos mitades)
+
+El firmador local tiene dos partes que hablan entre sí por un puerto local
+(`127.0.0.1:8790`), sin salir nunca de tu computadora:
+
+1. **La extensión del navegador** (carpeta `interceptor_extension/`).
+   Usa la **API de depuración de Chrome** (la misma que usan las herramientas de
+   desarrollador) para leer las tramas del websocket del chat, y las reenvía a
+   VeTube. No inyecta nada en la página de TikTok.
+
+2. **La parte de VeTube** (`servicios/tiktok_interceptor.py` y
+   `servicios/tiktok_espejo.py`).
+   Un pequeño servidor local recibe esas tramas, y un "espejo" reemplaza el
+   cliente de websocket de `TikTokLive` por uno que lee de ese servidor en vez de
+   conectarse a TikTok. Para el resto de VeTube, el chat llega igual que siempre.
+
+El recorrido de un mensaje, de punta a punta:
+
+    TikTok  →  tu navegador (recibe el chat firmado)  →  la extensión copia la trama
+            →  127.0.0.1:8790  →  VeTube la decodifica  →  se lee en voz alta
+
+---
+
+## Instalar la extensión
+
+La extensión **no está en la Chrome Web Store**: viene con VeTube, en la carpeta
+
+    interceptor_extension/
+
+(al lado de este archivo). Para instalarla, una sola vez:
+
+1. Abrí Chrome y andá a `chrome://extensions`.
+2. Activá el **"Modo de desarrollador"** (interruptor arriba a la derecha).
+3. Pulsá **"Cargar descomprimida"** y elegí la carpeta `interceptor_extension`.
+4. Listo: aparece **"VeTube – puente del chat de TikTok Live"** en la lista.
+
+Sirve para Chrome y para navegadores basados en Chromium (Edge, Brave, etc.).
+
+---
+
+## Usarlo en VeTube
+
+En la pantalla de inicio, en el desplegable **"Capturar el chat de:"**, hay dos
+opciones para TikTok:
+
+- **"TikTok"** — usa el servicio de firmas de siempre (EulerStream).
+- **"TikTok (navegador, experimental)"** — usa el firmador local (este).
+
+Para leer un directo con el firmador local:
+
+1. Abrí el directo en tu navegador (con la extensión ya instalada). Verás que
+   Chrome muestra una barra que dice *"… está depurando este navegador"*: **es
+   normal y es la señal de que la extensión está leyendo el chat.** Se puede
+   ignorar; no la cierres.
+2. En VeTube, escribí el **mismo usuario** del directo (el `@usuario`, tal cual,
+   con guion bajo y todo si lo tiene).
+3. Elegí **"TikTok (navegador, experimental)"** en "Capturar el chat de:".
+4. Pulsá **Acceder**.
+
+El chat empieza a leerse. El usuario en VeTube y el del directo abierto en el
+navegador **tienen que ser el mismo**.
+
+---
+
+## Qué pasa si EulerStream falla (fallback)
+
+Si elegís **"TikTok"** normal (o "detectar") y la conexión por EulerStream falla,
+VeTube te ofrece pasar al navegador con un aviso:
+
+> No se pudo conectar al chat de TikTok por el servicio habitual (suele estar
+> caído). Se puede leer desde el navegador. Asegurate de tener la extensión de
+> VeTube instalada y este directo abierto en el navegador, y pulsá Aceptar cuando
+> esté listo.
+
+Si aceptás (con el directo abierto en el navegador), VeTube reintenta leyendo del
+navegador, sin reiniciar nada. Si cancelás, da el error de siempre. El aviso se
+ofrece una sola vez por conexión.
+
+---
+
+## Requisitos y límites
+
+- **Requiere un navegador Chrome/Chromium** con la extensión cargada.
+- **La extensión tiene que estar cargada antes de abrir el directo.** Si el
+  directo ya estaba abierto, recargá esa pestaña para que la extensión lo tome.
+- **No tengas las herramientas de desarrollador (F12) abiertas en la pestaña del
+  directo**: usan el mismo canal de depuración y chocan con la extensión.
+- Es **experimental**: sirve como alternativa cuando EulerStream se cae, no como
+  reemplazo definitivo.
+
+---
+
+## Seguridad y privacidad
+
+- **La extensión solo lee lo que tu navegador ya recibe.** No burla ninguna
+  protección: la firma la hace TikTok en tu propia sesión, como siempre.
+- **No sale tu cookie de sesión.** La extensión nunca envía `sessionid` ni ninguna
+  credencial de tu cuenta.
+- **Todo queda en tu computadora.** La extensión solo habla con `127.0.0.1:8790`
+  (VeTube); nada se manda a ningún tercero.
+- **No modifica la página de TikTok** ni su seguridad: solo observa el tráfico del
+  chat, del mismo modo que lo verían las herramientas de desarrollador.
+
+---
+
+## Si algo no anda (diagnóstico)
+
+La extensión tiene un **popup accesible** (pulsá su ícono en la barra de Chrome).
+Pensado para lectores de pantalla, dice en palabras:
+
+- si VeTube está escuchando en el puerto 8790,
+- cuántas pestañas de TikTok tiene enganchadas,
+- cuántas tramas del chat leyó,
+- y un cuadro de "Diagnóstico" que se puede copiar entero (sin datos privados).
+
+Casos típicos:
+
+- **"VeTube escuchando: no"** → VeTube no está abierto, o no iniciaste el chat con
+  "TikTok (navegador)".
+- **No hay ninguna pestaña enganchada** → abrí el directo, o recargá su pestaña si
+  ya estaba abierta antes de instalar/recargar la extensión.
+- **VeTube dice que el usuario no existe / no está en vivo** → revisá que el
+  `@usuario` en VeTube sea idéntico al del directo abierto en el navegador.
+
+---
+
+## Para desarrolladores
+
+**Archivos de la extensión** (`interceptor_extension/`):
+
+- `manifest.json` — declara la extensión (Manifest V3) y sus permisos: `debugger`,
+  `storage` y acceso a `*.tiktok.com` y al puerto local.
+- `background.js` — el service worker. Adjunta el depurador a las pestañas de
+  TikTok, escucha `Network.webSocketFrameReceived`, filtra el websocket del
+  webcast por host, agrupa las tramas en lotes y las postea a VeTube.
+- `logica.js` — lógica pura (filtro de host, base64, agrupado, contador de
+  secuencia), sin tocar el navegador, para poder testearla con Node.
+- `popup.html` / `popup.js` — el popup de estado accesible.
+- `pruebas/pruebas.js` — banco de pruebas de la lógica pura, ejecutable con Node
+  sin navegador.
+
+**Archivos de VeTube:**
+
+- `servicios/tiktok_interceptor.py` — servidor local. Contrato (todo por
+  `http://127.0.0.1:8790`, JSON):
+  - `GET  /salud`   → `{"ok": true, "version": 2}`
+  - `POST /sesion`  → aviso de apertura/cierre de un directo.
+  - `POST /tramas`  → `{"unique_id", "room_id", "seq", "tramas": ["<base64>", …]}`.
+    `seq` es un contador por sesión para detectar lotes perdidos.
+- `servicios/tiktok_espejo.py` — el "espejo": reemplaza `client._ws` y el paso de
+  firma de `TikTokLiveClient` por uno que lee de la cola que llena el servidor
+  local. No firma ni abre conexiones a TikTok.
+- `servicios/tiktok.py` — instala el espejo según la opción elegida y ofrece el
+  fallback al navegador si EulerStream falla.
+
+**Tests** (`tests/test_tiktok_interceptor.py`, `tests/test_tiktok_espejo.py`):
+ejercitan el parseo de tramas con protobuf sintético, sin tocar la red real de
+TikTok. Se corren con `pytest tests/`.
+
+**Por qué la API de depuración y no un content script:** para leer las tramas hay
+que estar en el contexto de la página. Pero la CSP de TikTok (su `script-src` no
+incluye `'self'` ni `'unsafe-inline'`) **bloquea los content scripts del mundo
+MAIN** — la documentación de Chrome lo dice explícito. La API de depuración lee las
+tramas sin inyectar nada en la página, así que es inmune a la CSP.

--- a/controller/main_controller.py
+++ b/controller/main_controller.py
@@ -317,6 +317,8 @@ class MainController:
                 url = "https://www.twitch.tv/" + url
             elif plataforma_ids == 3:
                 url = "https://www.tiktok.com/@" + url + "/live"
+            elif plataforma_ids == 7:  # TikTok leido del navegador (firmador local)
+                url = "https://www.tiktok.com/@" + url + "/live"
             elif plataforma_ids == 5:  # Nuevo: Kick
                 url = "https://www.kick.com/" + url
             elif (
@@ -345,7 +347,10 @@ class MainController:
         elif "twitch" in url:
             self.set_plataforma(2)
         elif "tiktok" in url:
-            self.set_plataforma(3)
+            # Preservar la eleccion del navegador (indice 7). Sin esto, al haber
+            # construido una URL de tiktok, este autodetectado reajustaria el
+            # desplegable a 3 (TikTok normal) y se perderia el modo navegador.
+            self.set_plataforma(7 if plataforma_ids == 7 else 3)
         elif "sala" in url:
             self.set_plataforma(4)
         elif "kick" in url:  # Nuevo: Detección de URL para Kick
@@ -395,6 +400,14 @@ class MainController:
         # como genérica.
         plataforma = PLATAFORMAS[plataforma_ids]
 
+        # El origen del chat de TikTok se elige aca, en el desplegable "Capturar
+        # el chat de:": el indice 7 ("TikTok (navegador)") usa el firmador local
+        # (lee del navegador con la extension); el 3 ("TikTok") usa el firmador
+        # remoto de siempre. Es una bandera de ejecucion, no una preferencia
+        # guardada: se fija en cada conexion para que no queden dudas de que
+        # servicio esta en uso. La lee servicios/tiktok._instalar_firmador_local.
+        config["tiktok_firmador_local"] = plataforma_ids == 7
+
         # Create ChatController first
         chat_controller = ChatController(
             self, self.frame, plataforma=plataforma, chat_dialog=self.chat_dialog
@@ -411,6 +424,10 @@ class MainController:
                     self, url, self.frame, plataforma, chat_controller
                 )
             elif plataforma_ids == 3:
+                servicio = ServicioTiktok(
+                    self, url, self.frame, plataforma, chat_controller
+                )
+            elif plataforma_ids == 7:  # TikTok leido del navegador
                 servicio = ServicioTiktok(
                     self, url, self.frame, plataforma, chat_controller
                 )

--- a/interceptor_extension/LEEME.md
+++ b/interceptor_extension/LEEME.md
@@ -1,278 +1,68 @@
-# Puente del chat de TikTok Live para VeTube
+# VeTube – puente del chat de TikTok Live (extensión)
 
-La mitad que vive en el navegador. **Copia las tramas del chat que tu navegador
-ya está recibiendo del directo** y se las pasa a VeTube por `127.0.0.1:8790`.
+Esta es la **mitad que vive en el navegador** del firmador local de VeTube. Lee
+las tramas del chat que tu navegador ya recibe del directo y se las pasa a VeTube
+por `127.0.0.1:8790`. No recalcula ninguna firma ni manda tu cookie de sesión.
 
-No recalcula ninguna firma, no burla nada y no manda tu sesión a ningún sitio:
-la petición firmada la hace tu propio navegador cuando abrís el directo, como
-la haría igual sin la extensión. Esto sólo mira y copia.
+> La explicación completa del firmador (las dos mitades, cómo se usa en VeTube,
+> seguridad, diagnóstico) está en `../FIRMADOR_LOCAL.md`. Este archivo cubre solo
+> la extensión: cómo instalarla y cómo está hecha.
 
----
-
-## Por qué existe
-
-El websocket del chat de TikTok exige que la petición vaya firmada.
-`TikTokLive` delegaba esa firma en EulerStream, que está caído desde el
-2026-09-09, y no hay firmador alternativo aceptable. Pero tu navegador, al
-abrir el directo, **ya hace la petición firmada él solo**. La extensión se
-engancha a ese websocket ya abierto y reenvía lo que llega.
-
----
-
-## Ruta A y ruta B
-
-Hay dos formas de aprovechar lo que hace el navegador, y esta extensión hace
-las dos, pero sólo una es el camino de verdad.
-
-**Ruta A — pasarle a VeTube la URL ya firmada** (`POST /captura`). Es frágil:
-en `ws_connect.py` de TikTokLive está documentado que las URLs firmadas
-**caducan a los 30 segundos**, y encima el navegador ya gastó ésa. Se sigue
-enviando porque el contrato la incluye y porque de paso le lleva a VeTube las
-cookies y el `room_id`, pero no se puede depender de ella.
-
-**Ruta B — copiar las tramas** (`POST /tramas`). **Éste es el camino
-principal.** El navegador mantiene su websocket abierto y la extensión añade su
-propio oyente a los mensajes que llegan, los pasa a base64 y los reenvía en
-lotes. Nunca se reutiliza una firma porque nunca se vuelve a firmar nada: se
-aprovecha la conexión que ya está viva.
-
-Las tramas se reenvían **intactas**. Son `WebcastPushFrame` de protobuf y la
-extensión no las mira por dentro: eso es cosa del lado Python.
-
----
-
-## Qué hace cada archivo
-
-| Archivo | Dónde corre | Para qué |
-|---|---|---|
-| `manifest.json` | — | Declara la extensión (Manifest V3) y sus permisos. |
-| `logica.js` | en los tres sitios | Lógica pura: filtro de host, base64, agrupado en lotes, contador `seq`, lista blanca de cookies. Sin DOM, sin `chrome.*`, sin red: por eso se puede probar con Node. |
-| `inject.js` | mundo de la página | Envuelve `window.WebSocket` para **escuchar** las tramas del webcast. |
-| `content.js` | mundo aislado | Agrupa en lotes, sigue el `@usuario` de la ruta y mantiene despierto al service worker. |
-| `background.js` | service worker | La única pieza que habla con VeTube. Reúne las cookies y postea. |
-| `popup.html` / `popup.js` | popup | Estado, pensado para leerse con NVDA. |
-| `pruebas/pruebas.js` | Node | Banco de pruebas, sin navegador. |
-
----
-
-## Instalación
+## Cómo instalarla
 
 1. Abrí `chrome://extensions`.
-2. Activá **Modo de desarrollador** (arriba a la derecha).
-3. **Cargar descomprimida** y elegí esta carpeta.
-4. Si ya tenías un directo abierto, **recargá esa pestaña** (ver más abajo por qué).
+2. Activá el **"Modo de desarrollador"** (arriba a la derecha).
+3. Pulsá **"Cargar descomprimida"** y elegí **esta carpeta** (`interceptor_extension`).
+4. Aparece **"VeTube – puente del chat de TikTok Live"**.
 
-No hay que compilar nada: es JavaScript plano, sin dependencias ni build.
-
----
+Sirve en Chrome y en navegadores basados en Chromium (Edge, Brave, etc.).
 
 ## Cómo probarla
 
-### Sin navegador (rápido, cada vez que se toque el código)
+1. Abrí VeTube (o el receptor de prueba `../recibir_captura.py`, que levanta el
+   mismo servidor local e imprime, sin secretos, qué va llegando).
+2. Abrí un directo de TikTok: `https://www.tiktok.com/@usuario/live`.
+3. Chrome mostrará la barra *"… está depurando este navegador"*: **es normal**, es
+   la señal de que la extensión está leyendo el chat.
+4. Mirá el popup de la extensión (su ícono en la barra): dice si VeTube escucha,
+   cuántas pestañas tiene enganchadas y cuántas tramas leyó.
 
-```
-cd "C:\Users\phaza\cosas github\VeTube\interceptor_extension"
-node pruebas/pruebas.js
-```
+Si el directo ya estaba abierto antes de instalar/recargar la extensión, **recargá
+esa pestaña**: la extensión tiene que engancharse antes de que se abra el websocket.
+Y **no tengas las herramientas de desarrollador (F12) abiertas** en esa pestaña:
+usan el mismo canal de depuración y chocan.
 
-Ejercita el filtro de host (incluido que el websocket de la mensajería privada
-se descarte), la conversión a base64 de ida y vuelta, el agrupado en lotes con
-su tope de memoria, el contador `seq`, la lista blanca de cookies, el manifiesto
-y la accesibilidad del popup. Termina con un recuento y sale con código 1 si
-algo falla.
+## Qué hace cada archivo
 
-### Con un directo de verdad
+- `manifest.json` — declara la extensión (Manifest V3) y sus permisos: `debugger`,
+  `storage`, y acceso a `*.tiktok.com` y a `127.0.0.1:8790`.
+- `background.js` — el service worker, y el corazón de la captura. Adjunta el
+  depurador (`chrome.debugger`) a las pestañas de TikTok, activa el dominio
+  `Network` y escucha `Network.webSocketFrameReceived`. Filtra el websocket del
+  webcast por host (`webcast-ws.tiktok.com`), agrupa las tramas binarias en lotes
+  y las postea a VeTube. Las tramas binarias ya vienen en base64, que es justo lo
+  que VeTube espera.
+- `logica.js` — lógica pura (filtro de host, base64, agrupado en lotes, contador
+  de secuencia). No toca el navegador, para poder probarla con Node.
+- `popup.html` / `popup.js` — popup de estado, pensado para lectores de pantalla:
+  todo el estado escrito con palabras, sin depender de color ni de iconos.
+- `pruebas/pruebas.js` — banco de pruebas de `logica.js`, ejecutable sin navegador
+  (`node pruebas/pruebas.js`).
 
-1. Poné en marcha VeTube (o el receptor de prueba `recibir_captura.py`), que
-   escucha en `http://127.0.0.1:8790`.
-2. Abrí un directo: `https://www.tiktok.com/@quien_sea/live`.
-3. Abrí el popup de la extensión (icono en la barra) y comprobá que dice
-   *"Todo en marcha"* y que el contador de tramas sube.
-4. Si algo no encaja, el popup trae un cuadro de **diagnóstico** que se puede
-   copiar entero y pegar en un informe: lleva el host, la ruta y los **nombres**
-   de los parámetros, nunca los valores ni la URL firmada.
+## Por qué la API de depuración
 
----
+Para leer las tramas del websocket hay que estar en el contexto de la página. Pero
+la CSP de TikTok (su `script-src` no incluye `'self'` ni `'unsafe-inline'`)
+**bloquea los content scripts del mundo MAIN** — la documentación de Chrome lo dice
+explícito: *"cuando un content script se inyecta en el mundo MAIN, se aplica la CSP
+de la página"*. Por eso la captura no se hace inyectando código en la página, sino
+con la API de depuración, que lee las tramas igual que las herramientas de
+desarrollador y es inmune a la CSP.
 
-## Contrato con VeTube
+## Notas de seguridad
 
-Todo contra `http://127.0.0.1:8790`.
-
-```
-GET  /salud    -> 200 {"ok": true, "version": 2}
-POST /captura  -> ruta A. {"unique_id","room_id","ws_url","cookies":{...},"cursor"}
-POST /sesion   -> aviso de estado. {"unique_id","room_id","estado":"abierto"|"cerrado","ws_url"}
-POST /tramas   -> ruta B. {"unique_id","room_id","seq":<entero>,"tramas":["<base64>", ...]}
-                  respuesta: {"ok": true, "recibidas": <n>}
-```
-
-### Qué significa exactamente `seq`
-
-El contrato pide *"entero monotónico por sesión"*. Aquí **`seq` numera lotes, no
-tramas**: el primer `POST /tramas` de una sesión lleva `seq: 0`, el siguiente
-`seq: 1`, y así. Con `tramas` siendo una lista, un `seq` por trama sería ambiguo
-(¿el de la primera?, ¿el de la última?); numerando el lote, el lado Python tiene
-una comprobación trivial: **si el `seq` que llega no es el anterior + 1, se
-perdió un lote.**
-
-Y una **sesión** es *(socket interceptado + `@usuario` que se está viendo)*.
-Importa por lo que se explica abajo sobre la conexión reutilizada: al cambiar de
-directo, el socket es el mismo pero la sesión es otra, así que se manda un
-`/sesion cerrado`, un `/sesion abierto` y el `seq` vuelve a empezar en 0.
-
-`unique_id` es el dato **autoritativo**; `room_id` es el mejor esfuerzo y puede
-venir viejo (otra vez, la conexión reutilizada).
-
----
-
-## Lo aprendido
-
-### 1. Una página de tiktok.com no puede llamar a 127.0.0.1
-
-Comprobado en campo: un servidor local responde `200` a `curl`, y la petición
-del navegador **ni siquiera se registra en el servidor**. Chrome la corta antes
-de emitirla.
-
-Es **Local Network Access (LNA)**: desde Chrome 142 un origen público no alcanza
-loopback (`127.0.0.1`, `localhost`, `.local`) sin permiso. Por eso el `POST`
-**tiene** que salir del service worker.
-
-**Sobre si hace falta declarar algo en el manifiesto: no.** No existe un permiso
-`localNetworkAccess` para extensiones. El criterio de Chrome es que *"mientras
-una extensión tenga los host permissions correctos, esto no le afecta"*, y
-nuestro `host_permissions` ya incluye `http://127.0.0.1:8790/*`. Con eso basta.
-
-El único matiz, y conviene tenerlo escrito: **hubo un bug** por el que a
-extensiones con host permissions correctos les fallaban igualmente las
-peticiones a la red local (`crbug.com/435246545`, y otro relacionado, el
-`456078996`). Se arregló en Chrome **144**. Esta máquina tiene Chrome **152**,
-o sea muy por encima del arreglo. Si alguna vez esto se prueba en un Chrome
-entre el 142 y el 143, ése es el primer sospechoso.
-
-### 2. El service worker se duerme, y se resolvió con un latido
-
-El service worker de MV3 se apaga **a los 30 segundos de ocio**. Al despertar,
-sus variables globales están en blanco. Dos problemas distintos y dos arreglos:
-
-- **Que no se duerma mientras hay chat.** `content.js` mantiene un puerto de
-  larga duración (`chrome.runtime.connect`) y manda un latido cada **20 s**.
-  Desde Chrome 114, mandar mensajes por un puerto abierto reinicia el
-  temporizador de ocio. El latido sólo corre **mientras hay un directo
-  enganchado**: en una pestaña cualquiera de TikTok no se mantiene despierto a
-  nadie. En la práctica el propio tráfico ya lo mantiene vivo (un lote cada
-  250 ms), pero el latido cubre los ratos en que el chat se queda callado.
-- **Que si aun así se muere, no se pierda nada.** Todo el estado que no puede
-  reiniciarse —sobre todo el contador `seq`— vive en `chrome.storage.session`,
-  no en variables globales. Y el `seq` **se guarda antes de postear**: si el
-  worker muere en mitad del envío, al volver arranca en el siguiente. Un hueco
-  lo detecta el lado Python; un `seq` repetido lo confundiría de verdad.
-
-Detalle que casi muerde: **el worker también muere si un `fetch` tarda más de
-30 s en responder**. Por eso los POST llevan `AbortSignal.timeout(5000)`.
-
-No se usa `chrome.alarms`: su periodo mínimo es de 30 s, justo el borde del ocio,
-así que llega tarde por diseño.
-
-### 3. La conexión se reutiliza entre salas
-
-El socket es `.../webcast/im/ws_proxy/ws_reuse_supplement/`, y ese
-`ws_reuse_supplement` va en serio: al pasar de un directo a otro **no se abre un
-socket nuevo**, el cambio de sala viaja como mensaje por el mismo socket. De ahí
-salen dos consecuencias:
-
-- **El `room_id` de la query se queda viejo.** Por eso el dato autoritativo es
-  el `@usuario` de `location.pathname`, que `content.js` vigila cada segundo
-  para enterarse de las navegaciones del SPA.
-- **Si la extensión se carga con la página ya abierta, no ve nada.** El socket
-  ya existía y no hay forma de engancharse a posteriori. El popup lo detecta
-  (está en un directo pero no hay sesión abierta para ese usuario) y muestra el
-  aviso con un botón para recargar.
-
-### 4. Hay un segundo websocket que hay que descartar
-
-En la misma pestaña convive `wss://im-ws-sg.tiktok.com/ws/v2`, que es la
-mensajería privada y no tiene nada que ver con el chat del directo. El filtro es
-**por host**: la primera etiqueta del dominio tiene que empezar por `webcast` y
-el dominio tiene que ser `tiktok.com` de verdad (nada de trucos de sufijo tipo
-`evil-tiktok.com`).
-
-El filtro del prototipo anterior miraba la URL entera, así que un simple
-`?from=webcast` en la query se lo colaba. Hay una prueba que lo deja por
-escrito.
-
-### 5. base64 en el mundo de la página, y por qué
-
-`chrome.runtime.sendMessage` y los puertos **serializan como JSON**: un
-`ArrayBuffer` o un `Uint8Array` NO sobreviven ese salto (llegan como `{}` o como
-un objeto con claves numéricas). Así que hay que pasar a base64 sí o sí; la
-única decisión es de qué lado del `postMessage`.
-
-Se hace **en el mundo de la página**, por tres razones:
-
-1. El `Blob` es un objeto de la página y `blob.arrayBuffer()` hay que llamarlo
-   ahí de todos modos. Pasar el `Blob` al otro mundo sólo mueve el mismo trabajo
-   de sitio.
-2. Un content script **corre en el mismo hilo que la página**, así que "pasarlo
-   al mundo aislado" no le ahorra ni un milisegundo al hilo principal. No hay
-   nada que ganar.
-3. Convirtiendo ahí, lo único que cruza el `postMessage` es una **cadena de
-   texto**: sin copia estructurada del binario, sin listas de transferencia, sin
-   sorpresas entre mundos, y ya en el formato exacto que pide el contrato.
-
-El agrupado en lotes, en cambio, está **en el mundo aislado**, porque el tope de
-memoria necesita saber si hay a quién entregarle las tramas: si el worker no
-está o VeTube no responde, quien tiene que aguantar y decidir qué se tira es el
-content script.
-
-### 6. `webRequest` sobraba: se quitó
-
-El prototipo pedía el permiso `webRequest` para ver el handshake del websocket.
-Con la ruta B no sirve de nada: `webRequest` **sólo ve el handshake, nunca las
-tramas** que viajan después, y la URL ya la da `inject.js`. Fuera. Los permisos
-que quedan son `cookies` (para la lista blanca) y `storage` (para el estado que
-sobrevive a las siestas del worker).
-
-### 7. `binaryType` es `"blob"`, y no se toca
-
-Las tramas llegan como `Blob`. Se podría poner `ws.binaryType = "arraybuffer"`
-y ahorrarse una conversión, pero eso **cambiaría lo que recibe el manejador de
-la propia página** y le rompería el chat a TikTok. Es interferir, así que no.
-Por lo mismo, el oyente se añade con `addEventListener` y nunca asignando
-`ws.onmessage`, que pisaría el de la página.
-
----
-
-## Seguridad
-
-- **Nunca se manda `sessionid`** ni ninguna otra credencial de sesión. La lista
-  blanca es exactamente `ttwid` y `tt-target-idc`, y hay una prueba que falla si
-  alguien la amplía con algo que huela a sesión. Está comprobado en campo que
-  con `user_is_login=false` el directo y su chat funcionan igual, así que no hay
-  ninguna excusa para ampliarla.
-- La extensión **sólo habla con `127.0.0.1:8790`**. Ningún tercero. Hay una
-  prueba que revisa cada archivo buscando URLs y falla si aparece otra cosa.
-- **No se modifica ni se bloquea el tráfico de la página.** Sólo se observa.
-- Permisos mínimos: `cookies`, `storage`, y host permissions para
-  `https://*.tiktok.com/*` y el puerto local. Nada más.
-- El diagnóstico del popup **no incluye la `ws_url` completa**, porque lleva la
-  firma `X-Bogus`: sólo el host, la ruta y los nombres de los parámetros.
-
----
-
-## Si algo no va
-
-**El popup dice "Hace falta recargar la página del directo".**
-La extensión se cargó o se actualizó con el directo ya abierto. El websocket ya
-existía y no se puede enganchar a posteriori. Recargá (el botón lo hace).
-
-**El popup dice "VeTube no responde en el puerto 8790".**
-VeTube no está abierto, o no llegó a levantar su servidor local. El detalle del
-error está en la lista.
-
-**El contador de tramas no sube pero sí hay chat en pantalla.**
-Mirá la consola del service worker (`chrome://extensions` → *Service Worker*).
-Si aparecen "lote perdido", VeTube está rechazando los POST.
-
-**Salen muchas "Tramas descartadas".**
-El buffer se llenó porque VeTube no las recibía. Se tiran las **más viejas** a
-propósito: en un chat en vivo lo que importa es lo que se dice ahora.
+- `sessionid` (la llave completa de tu cuenta) **nunca** se envía. La lista de
+  cookies permitidas se limita a lo inocuo, y de hecho el chat de un directo
+  público funciona sin login.
+- La extensión solo habla con `127.0.0.1:8790`. Ningún tercero.
+- No modifica ni bloquea el tráfico de la página: solo lo observa.

--- a/interceptor_extension/LEEME.md
+++ b/interceptor_extension/LEEME.md
@@ -1,0 +1,278 @@
+# Puente del chat de TikTok Live para VeTube
+
+La mitad que vive en el navegador. **Copia las tramas del chat que tu navegador
+ya está recibiendo del directo** y se las pasa a VeTube por `127.0.0.1:8790`.
+
+No recalcula ninguna firma, no burla nada y no manda tu sesión a ningún sitio:
+la petición firmada la hace tu propio navegador cuando abrís el directo, como
+la haría igual sin la extensión. Esto sólo mira y copia.
+
+---
+
+## Por qué existe
+
+El websocket del chat de TikTok exige que la petición vaya firmada.
+`TikTokLive` delegaba esa firma en EulerStream, que está caído desde el
+2026-09-09, y no hay firmador alternativo aceptable. Pero tu navegador, al
+abrir el directo, **ya hace la petición firmada él solo**. La extensión se
+engancha a ese websocket ya abierto y reenvía lo que llega.
+
+---
+
+## Ruta A y ruta B
+
+Hay dos formas de aprovechar lo que hace el navegador, y esta extensión hace
+las dos, pero sólo una es el camino de verdad.
+
+**Ruta A — pasarle a VeTube la URL ya firmada** (`POST /captura`). Es frágil:
+en `ws_connect.py` de TikTokLive está documentado que las URLs firmadas
+**caducan a los 30 segundos**, y encima el navegador ya gastó ésa. Se sigue
+enviando porque el contrato la incluye y porque de paso le lleva a VeTube las
+cookies y el `room_id`, pero no se puede depender de ella.
+
+**Ruta B — copiar las tramas** (`POST /tramas`). **Éste es el camino
+principal.** El navegador mantiene su websocket abierto y la extensión añade su
+propio oyente a los mensajes que llegan, los pasa a base64 y los reenvía en
+lotes. Nunca se reutiliza una firma porque nunca se vuelve a firmar nada: se
+aprovecha la conexión que ya está viva.
+
+Las tramas se reenvían **intactas**. Son `WebcastPushFrame` de protobuf y la
+extensión no las mira por dentro: eso es cosa del lado Python.
+
+---
+
+## Qué hace cada archivo
+
+| Archivo | Dónde corre | Para qué |
+|---|---|---|
+| `manifest.json` | — | Declara la extensión (Manifest V3) y sus permisos. |
+| `logica.js` | en los tres sitios | Lógica pura: filtro de host, base64, agrupado en lotes, contador `seq`, lista blanca de cookies. Sin DOM, sin `chrome.*`, sin red: por eso se puede probar con Node. |
+| `inject.js` | mundo de la página | Envuelve `window.WebSocket` para **escuchar** las tramas del webcast. |
+| `content.js` | mundo aislado | Agrupa en lotes, sigue el `@usuario` de la ruta y mantiene despierto al service worker. |
+| `background.js` | service worker | La única pieza que habla con VeTube. Reúne las cookies y postea. |
+| `popup.html` / `popup.js` | popup | Estado, pensado para leerse con NVDA. |
+| `pruebas/pruebas.js` | Node | Banco de pruebas, sin navegador. |
+
+---
+
+## Instalación
+
+1. Abrí `chrome://extensions`.
+2. Activá **Modo de desarrollador** (arriba a la derecha).
+3. **Cargar descomprimida** y elegí esta carpeta.
+4. Si ya tenías un directo abierto, **recargá esa pestaña** (ver más abajo por qué).
+
+No hay que compilar nada: es JavaScript plano, sin dependencias ni build.
+
+---
+
+## Cómo probarla
+
+### Sin navegador (rápido, cada vez que se toque el código)
+
+```
+cd "C:\Users\phaza\cosas github\VeTube\interceptor_extension"
+node pruebas/pruebas.js
+```
+
+Ejercita el filtro de host (incluido que el websocket de la mensajería privada
+se descarte), la conversión a base64 de ida y vuelta, el agrupado en lotes con
+su tope de memoria, el contador `seq`, la lista blanca de cookies, el manifiesto
+y la accesibilidad del popup. Termina con un recuento y sale con código 1 si
+algo falla.
+
+### Con un directo de verdad
+
+1. Poné en marcha VeTube (o el receptor de prueba `recibir_captura.py`), que
+   escucha en `http://127.0.0.1:8790`.
+2. Abrí un directo: `https://www.tiktok.com/@quien_sea/live`.
+3. Abrí el popup de la extensión (icono en la barra) y comprobá que dice
+   *"Todo en marcha"* y que el contador de tramas sube.
+4. Si algo no encaja, el popup trae un cuadro de **diagnóstico** que se puede
+   copiar entero y pegar en un informe: lleva el host, la ruta y los **nombres**
+   de los parámetros, nunca los valores ni la URL firmada.
+
+---
+
+## Contrato con VeTube
+
+Todo contra `http://127.0.0.1:8790`.
+
+```
+GET  /salud    -> 200 {"ok": true, "version": 2}
+POST /captura  -> ruta A. {"unique_id","room_id","ws_url","cookies":{...},"cursor"}
+POST /sesion   -> aviso de estado. {"unique_id","room_id","estado":"abierto"|"cerrado","ws_url"}
+POST /tramas   -> ruta B. {"unique_id","room_id","seq":<entero>,"tramas":["<base64>", ...]}
+                  respuesta: {"ok": true, "recibidas": <n>}
+```
+
+### Qué significa exactamente `seq`
+
+El contrato pide *"entero monotónico por sesión"*. Aquí **`seq` numera lotes, no
+tramas**: el primer `POST /tramas` de una sesión lleva `seq: 0`, el siguiente
+`seq: 1`, y así. Con `tramas` siendo una lista, un `seq` por trama sería ambiguo
+(¿el de la primera?, ¿el de la última?); numerando el lote, el lado Python tiene
+una comprobación trivial: **si el `seq` que llega no es el anterior + 1, se
+perdió un lote.**
+
+Y una **sesión** es *(socket interceptado + `@usuario` que se está viendo)*.
+Importa por lo que se explica abajo sobre la conexión reutilizada: al cambiar de
+directo, el socket es el mismo pero la sesión es otra, así que se manda un
+`/sesion cerrado`, un `/sesion abierto` y el `seq` vuelve a empezar en 0.
+
+`unique_id` es el dato **autoritativo**; `room_id` es el mejor esfuerzo y puede
+venir viejo (otra vez, la conexión reutilizada).
+
+---
+
+## Lo aprendido
+
+### 1. Una página de tiktok.com no puede llamar a 127.0.0.1
+
+Comprobado en campo: un servidor local responde `200` a `curl`, y la petición
+del navegador **ni siquiera se registra en el servidor**. Chrome la corta antes
+de emitirla.
+
+Es **Local Network Access (LNA)**: desde Chrome 142 un origen público no alcanza
+loopback (`127.0.0.1`, `localhost`, `.local`) sin permiso. Por eso el `POST`
+**tiene** que salir del service worker.
+
+**Sobre si hace falta declarar algo en el manifiesto: no.** No existe un permiso
+`localNetworkAccess` para extensiones. El criterio de Chrome es que *"mientras
+una extensión tenga los host permissions correctos, esto no le afecta"*, y
+nuestro `host_permissions` ya incluye `http://127.0.0.1:8790/*`. Con eso basta.
+
+El único matiz, y conviene tenerlo escrito: **hubo un bug** por el que a
+extensiones con host permissions correctos les fallaban igualmente las
+peticiones a la red local (`crbug.com/435246545`, y otro relacionado, el
+`456078996`). Se arregló en Chrome **144**. Esta máquina tiene Chrome **152**,
+o sea muy por encima del arreglo. Si alguna vez esto se prueba en un Chrome
+entre el 142 y el 143, ése es el primer sospechoso.
+
+### 2. El service worker se duerme, y se resolvió con un latido
+
+El service worker de MV3 se apaga **a los 30 segundos de ocio**. Al despertar,
+sus variables globales están en blanco. Dos problemas distintos y dos arreglos:
+
+- **Que no se duerma mientras hay chat.** `content.js` mantiene un puerto de
+  larga duración (`chrome.runtime.connect`) y manda un latido cada **20 s**.
+  Desde Chrome 114, mandar mensajes por un puerto abierto reinicia el
+  temporizador de ocio. El latido sólo corre **mientras hay un directo
+  enganchado**: en una pestaña cualquiera de TikTok no se mantiene despierto a
+  nadie. En la práctica el propio tráfico ya lo mantiene vivo (un lote cada
+  250 ms), pero el latido cubre los ratos en que el chat se queda callado.
+- **Que si aun así se muere, no se pierda nada.** Todo el estado que no puede
+  reiniciarse —sobre todo el contador `seq`— vive en `chrome.storage.session`,
+  no en variables globales. Y el `seq` **se guarda antes de postear**: si el
+  worker muere en mitad del envío, al volver arranca en el siguiente. Un hueco
+  lo detecta el lado Python; un `seq` repetido lo confundiría de verdad.
+
+Detalle que casi muerde: **el worker también muere si un `fetch` tarda más de
+30 s en responder**. Por eso los POST llevan `AbortSignal.timeout(5000)`.
+
+No se usa `chrome.alarms`: su periodo mínimo es de 30 s, justo el borde del ocio,
+así que llega tarde por diseño.
+
+### 3. La conexión se reutiliza entre salas
+
+El socket es `.../webcast/im/ws_proxy/ws_reuse_supplement/`, y ese
+`ws_reuse_supplement` va en serio: al pasar de un directo a otro **no se abre un
+socket nuevo**, el cambio de sala viaja como mensaje por el mismo socket. De ahí
+salen dos consecuencias:
+
+- **El `room_id` de la query se queda viejo.** Por eso el dato autoritativo es
+  el `@usuario` de `location.pathname`, que `content.js` vigila cada segundo
+  para enterarse de las navegaciones del SPA.
+- **Si la extensión se carga con la página ya abierta, no ve nada.** El socket
+  ya existía y no hay forma de engancharse a posteriori. El popup lo detecta
+  (está en un directo pero no hay sesión abierta para ese usuario) y muestra el
+  aviso con un botón para recargar.
+
+### 4. Hay un segundo websocket que hay que descartar
+
+En la misma pestaña convive `wss://im-ws-sg.tiktok.com/ws/v2`, que es la
+mensajería privada y no tiene nada que ver con el chat del directo. El filtro es
+**por host**: la primera etiqueta del dominio tiene que empezar por `webcast` y
+el dominio tiene que ser `tiktok.com` de verdad (nada de trucos de sufijo tipo
+`evil-tiktok.com`).
+
+El filtro del prototipo anterior miraba la URL entera, así que un simple
+`?from=webcast` en la query se lo colaba. Hay una prueba que lo deja por
+escrito.
+
+### 5. base64 en el mundo de la página, y por qué
+
+`chrome.runtime.sendMessage` y los puertos **serializan como JSON**: un
+`ArrayBuffer` o un `Uint8Array` NO sobreviven ese salto (llegan como `{}` o como
+un objeto con claves numéricas). Así que hay que pasar a base64 sí o sí; la
+única decisión es de qué lado del `postMessage`.
+
+Se hace **en el mundo de la página**, por tres razones:
+
+1. El `Blob` es un objeto de la página y `blob.arrayBuffer()` hay que llamarlo
+   ahí de todos modos. Pasar el `Blob` al otro mundo sólo mueve el mismo trabajo
+   de sitio.
+2. Un content script **corre en el mismo hilo que la página**, así que "pasarlo
+   al mundo aislado" no le ahorra ni un milisegundo al hilo principal. No hay
+   nada que ganar.
+3. Convirtiendo ahí, lo único que cruza el `postMessage` es una **cadena de
+   texto**: sin copia estructurada del binario, sin listas de transferencia, sin
+   sorpresas entre mundos, y ya en el formato exacto que pide el contrato.
+
+El agrupado en lotes, en cambio, está **en el mundo aislado**, porque el tope de
+memoria necesita saber si hay a quién entregarle las tramas: si el worker no
+está o VeTube no responde, quien tiene que aguantar y decidir qué se tira es el
+content script.
+
+### 6. `webRequest` sobraba: se quitó
+
+El prototipo pedía el permiso `webRequest` para ver el handshake del websocket.
+Con la ruta B no sirve de nada: `webRequest` **sólo ve el handshake, nunca las
+tramas** que viajan después, y la URL ya la da `inject.js`. Fuera. Los permisos
+que quedan son `cookies` (para la lista blanca) y `storage` (para el estado que
+sobrevive a las siestas del worker).
+
+### 7. `binaryType` es `"blob"`, y no se toca
+
+Las tramas llegan como `Blob`. Se podría poner `ws.binaryType = "arraybuffer"`
+y ahorrarse una conversión, pero eso **cambiaría lo que recibe el manejador de
+la propia página** y le rompería el chat a TikTok. Es interferir, así que no.
+Por lo mismo, el oyente se añade con `addEventListener` y nunca asignando
+`ws.onmessage`, que pisaría el de la página.
+
+---
+
+## Seguridad
+
+- **Nunca se manda `sessionid`** ni ninguna otra credencial de sesión. La lista
+  blanca es exactamente `ttwid` y `tt-target-idc`, y hay una prueba que falla si
+  alguien la amplía con algo que huela a sesión. Está comprobado en campo que
+  con `user_is_login=false` el directo y su chat funcionan igual, así que no hay
+  ninguna excusa para ampliarla.
+- La extensión **sólo habla con `127.0.0.1:8790`**. Ningún tercero. Hay una
+  prueba que revisa cada archivo buscando URLs y falla si aparece otra cosa.
+- **No se modifica ni se bloquea el tráfico de la página.** Sólo se observa.
+- Permisos mínimos: `cookies`, `storage`, y host permissions para
+  `https://*.tiktok.com/*` y el puerto local. Nada más.
+- El diagnóstico del popup **no incluye la `ws_url` completa**, porque lleva la
+  firma `X-Bogus`: sólo el host, la ruta y los nombres de los parámetros.
+
+---
+
+## Si algo no va
+
+**El popup dice "Hace falta recargar la página del directo".**
+La extensión se cargó o se actualizó con el directo ya abierto. El websocket ya
+existía y no se puede enganchar a posteriori. Recargá (el botón lo hace).
+
+**El popup dice "VeTube no responde en el puerto 8790".**
+VeTube no está abierto, o no llegó a levantar su servidor local. El detalle del
+error está en la lista.
+
+**El contador de tramas no sube pero sí hay chat en pantalla.**
+Mirá la consola del service worker (`chrome://extensions` → *Service Worker*).
+Si aparecen "lote perdido", VeTube está rechazando los POST.
+
+**Salen muchas "Tramas descartadas".**
+El buffer se llenó porque VeTube no las recibía. Se tiran las **más viejas** a
+propósito: en un chat en vivo lo que importa es lo que se dice ahora.

--- a/interceptor_extension/background.js
+++ b/interceptor_extension/background.js
@@ -1,0 +1,473 @@
+// Service worker: la única pieza que habla con VeTube, y ahora también la que
+// captura las tramas.
+//
+// POR QUÉ LA API DE DEPURACIÓN (chrome.debugger) Y NO UN CONTENT SCRIPT:
+// para leer las tramas del websocket hay que estar en el contexto de la página
+// (mundo MAIN). Pero la CSP de TikTok (script-src sin 'self' ni 'unsafe-inline')
+// BLOQUEA los content scripts del mundo MAIN: la documentación de Chrome lo dice
+// explícito ("cuando un content script se inyecta en el mundo MAIN, se aplica la
+// CSP de la página"), y se comprobó en campo (el inyector nunca arrancaba). La
+// API de depuración lee las tramas igual que las DevTools
+// (Network.webSocketFrameReceived), SIN inyectar nada en la página, así que es
+// inmune a la CSP. Precio: Chrome muestra una barra "está depurando este
+// navegador" mientras haya una pestaña de TikTok, y hace falta el permiso
+// "debugger".
+//
+// POR QUÉ EL POST SALE DE AQUÍ: una página de tiktok.com no puede hacer fetch a
+// http://127.0.0.1 (Local Network Access lo corta). El service worker sí llega,
+// con las host_permissions de la extensión.
+"use strict";
+
+importScripts("logica.js");
+const L = globalThis.__vetubeLogica;
+
+const BASE = "http://127.0.0.1:8790";
+const VERSION_CONTRATO = 2;
+const PROTO_DEPURADOR = "1.3";
+
+// El worker muere si un fetch tarda más de 30 s. Con 5 s vamos sobrados para un
+// servidor local.
+const MS_TIMEOUT = 5000;
+// Si VeTube no responde, no gastamos 5 s por lote: se marca caído un rato.
+const MS_ENFRIAMIENTO = 3000;
+
+// Agrupado de tramas del lado del worker (antes lo hacía el content script).
+const MS_LOTE = 250;
+const MAX_LOTE = 20;
+
+// ---------------------------------------------------------------------
+// Estado que sobrevive a las siestas del worker
+// ---------------------------------------------------------------------
+// El worker de MV3 se duerme a los ~30 s de ocio y pierde sus variables. Lo que
+// no puede reiniciarse (el contador seq, que el lado Python usa para detectar
+// lotes perdidos) vive en chrome.storage.session.
+const CLAVE = "estado";
+
+function estadoVacio() {
+  return {
+    sesiones: {}, // clave -> {unique_id, room_id, ws_url, abiertaMs, tabId}
+    seq: {}, // clave -> siguiente seq a usar
+    paginas: {}, // tabId -> {unique_id, esDirecto, socketVisto, cuandoMs}
+    contadores: {
+      tramasEnviadas: 0,
+      lotesEnviados: 0,
+      lotesFallidos: 0,
+      tramasDescartadas: 0,
+      ultimaTramaMs: 0,
+    },
+    vetube: { ok: false, version: 0, ultimoChequeoMs: 0, ultimoError: "" },
+    // Diagnóstico de la captura por depurador, para que el popup lo muestre.
+    diag: {
+      modo: "debugger",
+      adjuntas: 0, // pestañas de TikTok con el depurador adjunto
+      wsWebcast: 0, // websockets del webcast vistos
+      framesWebcast: 0, // tramas del webcast leídas
+      ultimoError: "",
+    },
+    caidoHastaMs: 0,
+  };
+}
+
+let estado = null;
+let cargando = null;
+
+async function cargarEstado() {
+  if (estado) return estado;
+  if (!cargando) {
+    cargando = chrome.storage.session
+      .get(CLAVE)
+      .then(function (r) {
+        estado = Object.assign(estadoVacio(), (r && r[CLAVE]) || {});
+        if (!estado.diag || estado.diag.modo !== "debugger") {
+          estado.diag = estadoVacio().diag;
+        }
+        return estado;
+      })
+      .catch(function () {
+        estado = estadoVacio();
+        return estado;
+      });
+  }
+  return cargando;
+}
+
+function guardarEstado() {
+  return chrome.storage.session.set({ [CLAVE]: estado }).catch(function () {
+    /* si falla, lo peor que pasa es que el seq se reinicie tras una siesta */
+  });
+}
+
+// Todo lo que toca seq o postea pasa por esta cadena, para que dos lotes que
+// entran a la vez no lean el mismo seq y lo manden repetido (peor que un hueco).
+let cadena = Promise.resolve();
+function encolar(tarea) {
+  cadena = cadena.then(tarea).catch(function (e) {
+    console.warn("[VeTube] error en la cola:", String(e));
+  });
+  return cadena;
+}
+
+function seguro(fn) {
+  try {
+    return fn();
+  } catch (e) {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------
+// Red
+// ---------------------------------------------------------------------
+async function postear(ruta, cuerpo) {
+  const r = await fetch(BASE + ruta, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(cuerpo),
+    signal: AbortSignal.timeout(MS_TIMEOUT),
+  });
+  if (!r.ok) throw new Error("HTTP " + r.status);
+  return r;
+}
+
+async function comprobarSalud() {
+  const st = await cargarEstado();
+  try {
+    const r = await fetch(BASE + "/salud", { signal: AbortSignal.timeout(2000) });
+    const datos = await r.json();
+    st.vetube = {
+      ok: datos && datos.ok === true,
+      version: (datos && datos.version) || 0,
+      ultimoChequeoMs: Date.now(),
+      ultimoError: "",
+    };
+  } catch (e) {
+    st.vetube = {
+      ok: false,
+      version: 0,
+      ultimoChequeoMs: Date.now(),
+      ultimoError: String(e && e.message ? e.message : e),
+    };
+  }
+  await guardarEstado();
+  return st.vetube;
+}
+
+// ---------------------------------------------------------------------
+// Sesiones y lotes (contrato con VeTube: /sesion y /tramas)
+// ---------------------------------------------------------------------
+function claveDbg(tabId, requestId) {
+  return "dbg:" + tabId + ":" + requestId;
+}
+
+async function abrirSesion(clave, info) {
+  const st = await cargarEstado();
+  st.sesiones[clave] = {
+    unique_id: info.unique_id || "",
+    room_id: info.room_id || "",
+    ws_url: info.url || "",
+    abiertaMs: Date.now(),
+    tabId: info.tabId,
+  };
+  st.seq[clave] = 0;
+  st.diag.wsWebcast = (st.diag.wsWebcast || 0) + 1;
+  await guardarEstado();
+  try {
+    await postear("/sesion", {
+      unique_id: info.unique_id || "",
+      room_id: info.room_id || "",
+      estado: "abierto",
+      ws_url: info.url || "",
+    });
+    console.log("[VeTube] sesión abierta para @" + (info.unique_id || "?"));
+  } catch (e) {
+    console.warn("[VeTube] /sesion abierto no salió:", String(e));
+  }
+}
+
+async function cerrarSesion(clave, info) {
+  const st = await cargarEstado();
+  const previa = st.sesiones[clave];
+  delete st.sesiones[clave];
+  delete st.seq[clave];
+  await guardarEstado();
+  const uid = (info && info.unique_id) || (previa && previa.unique_id) || "";
+  const room = (info && info.room_id) || (previa && previa.room_id) || "";
+  try {
+    await postear("/sesion", {
+      unique_id: uid,
+      room_id: room,
+      estado: "cerrado",
+      ws_url: "",
+    });
+  } catch (e) {
+    console.warn("[VeTube] /sesion cerrado no salió:", String(e));
+  }
+}
+
+async function enviarLote(clave, info, tramas) {
+  const st = await cargarEstado();
+  if (!tramas.length) return;
+  if (Date.now() < st.caidoHastaMs) {
+    st.contadores.tramasDescartadas += tramas.length;
+    await guardarEstado();
+    return;
+  }
+  const seq = st.seq[clave] || 0;
+  // Se persiste ANTES de postear: si el worker muere en mitad del envío, al
+  // volver arranca en el siguiente seq. Un hueco lo detecta Python; un seq
+  // repetido lo confundiría de verdad.
+  st.seq[clave] = seq + 1;
+  await guardarEstado();
+  try {
+    await postear("/tramas", {
+      unique_id: info.unique_id || "",
+      room_id: info.room_id || "",
+      seq: seq,
+      tramas: tramas,
+    });
+    st.contadores.tramasEnviadas += tramas.length;
+    st.contadores.lotesEnviados += 1;
+    st.contadores.ultimaTramaMs = Date.now();
+    st.diag.framesWebcast = (st.diag.framesWebcast || 0) + tramas.length;
+    if (!st.vetube.ok) st.vetube.ok = true;
+    st.caidoHastaMs = 0;
+  } catch (e) {
+    st.contadores.lotesFallidos += 1;
+    st.contadores.tramasDescartadas += tramas.length;
+    st.vetube.ok = false;
+    st.vetube.ultimoError = String(e && e.message ? e.message : e);
+    st.caidoHastaMs = Date.now() + MS_ENFRIAMIENTO;
+    console.warn("[VeTube] lote perdido:", st.vetube.ultimoError);
+  }
+  await guardarEstado();
+}
+
+// Agrupador en memoria del worker. clave -> {tramas, timer, info}
+const lotes = new Map();
+
+function acumularTrama(clave, info, b64) {
+  let lote = lotes.get(clave);
+  if (!lote) {
+    lote = { tramas: [], timer: null, info: info };
+    lotes.set(clave, lote);
+  }
+  lote.info = info;
+  lote.tramas.push(b64);
+  if (lote.tramas.length >= MAX_LOTE) {
+    descargarLote(clave);
+  } else if (!lote.timer) {
+    lote.timer = setTimeout(function () {
+      descargarLote(clave);
+    }, MS_LOTE);
+  }
+}
+
+function descargarLote(clave) {
+  const lote = lotes.get(clave);
+  if (!lote) return;
+  if (lote.timer) {
+    clearTimeout(lote.timer);
+    lote.timer = null;
+  }
+  const tramas = lote.tramas;
+  lote.tramas = [];
+  if (!tramas.length) return;
+  const info = lote.info || {};
+  encolar(function () {
+    return enviarLote(clave, info, tramas);
+  });
+}
+
+// ---------------------------------------------------------------------
+// Captura por API de depuración
+// ---------------------------------------------------------------------
+const adjuntas = new Set(); // tabIds con el depurador adjunto
+const wsPorTab = new Map(); // tabId -> Map(requestId -> {url, esWebcast, room_id, unique_id, tabId})
+
+function esTikTok(url) {
+  return typeof url === "string" && /^https?:\/\/([^/]+\.)?tiktok\.com\//i.test(url);
+}
+
+function marcarError(texto) {
+  encolar(async function () {
+    const st = await cargarEstado();
+    st.diag.ultimoError = texto;
+    st.diag.adjuntas = adjuntas.size;
+    await guardarEstado();
+  });
+}
+
+function adjuntar(tabId) {
+  if (tabId == null || adjuntas.has(tabId)) return;
+  adjuntas.add(tabId); // optimista; se revierte si falla
+  chrome.debugger.attach({ tabId: tabId }, PROTO_DEPURADOR, function () {
+    if (chrome.runtime.lastError) {
+      adjuntas.delete(tabId);
+      // Caso típico: ya hay unas DevTools abiertas en esa pestaña.
+      marcarError(String(chrome.runtime.lastError.message || chrome.runtime.lastError));
+      return;
+    }
+    chrome.debugger.sendCommand({ tabId: tabId }, "Network.enable", {}, function () {
+      void chrome.runtime.lastError;
+      encolar(async function () {
+        const st = await cargarEstado();
+        st.diag.adjuntas = adjuntas.size;
+        await guardarEstado();
+      });
+    });
+  });
+}
+
+function limpiarSesionesDeTab(tabId) {
+  const mapa = wsPorTab.get(tabId);
+  if (!mapa) return;
+  mapa.forEach(function (info, requestId) {
+    const clave = claveDbg(tabId, requestId);
+    descargarLote(clave);
+    if (info.esWebcast) {
+      encolar(function () {
+        return cerrarSesion(clave, info);
+      });
+    }
+  });
+  wsPorTab.delete(tabId);
+}
+
+// Adjuntar a las pestañas de TikTok que ya estén abiertas al arrancar el worker.
+chrome.tabs.query({ url: "*://*.tiktok.com/*" }, function (tabs) {
+  if (chrome.runtime.lastError) return;
+  (tabs || []).forEach(function (t) {
+    adjuntar(t.id);
+  });
+});
+
+// Adjuntar a las pestañas que naveguen a TikTok. Al empezar a cargar una página
+// nueva se cierran las sesiones viejas de esa pestaña (otro directo, u otra
+// cosa): sus tramas ya no vienen.
+chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
+  const url = (tab && tab.url) || info.url || "";
+  if (!esTikTok(url)) return;
+  if (info.status === "loading") limpiarSesionesDeTab(tabId);
+  adjuntar(tabId);
+});
+
+chrome.debugger.onEvent.addListener(function (source, metodo, params) {
+  const tabId = source.tabId;
+  if (tabId == null || !params) return;
+
+  if (metodo === "Network.webSocketCreated") {
+    const esWc = !!seguro(function () {
+      return L.esWebSocketDelWebcast(params.url);
+    });
+    let mapa = wsPorTab.get(tabId);
+    if (!mapa) {
+      mapa = new Map();
+      wsPorTab.set(tabId, mapa);
+    }
+    const info = {
+      url: params.url,
+      esWebcast: esWc,
+      room_id: seguro(function () {
+        return L.sacarRoomId(params.url);
+      }) || "",
+      unique_id: "",
+      tabId: tabId,
+    };
+    mapa.set(params.requestId, info);
+    if (esWc) {
+      // El @usuario del directo sale de la ruta de la pestaña; se busca aparte
+      // porque la url del websocket no siempre lo trae.
+      chrome.tabs.get(tabId, function (tab) {
+        void chrome.runtime.lastError;
+        const ruta = seguro(function () {
+          return new URL(tab && tab.url ? tab.url : "").pathname;
+        }) || "";
+        info.unique_id = seguro(function () {
+          return L.sacarUniqueIdDeRuta(ruta);
+        }) || "";
+        const clave = claveDbg(tabId, params.requestId);
+        encolar(function () {
+          return abrirSesion(clave, info);
+        });
+      });
+    }
+  } else if (metodo === "Network.webSocketFrameReceived") {
+    const mapa = wsPorTab.get(tabId);
+    const info = mapa && mapa.get(params.requestId);
+    if (!info || !info.esWebcast) return;
+    const fr = params.response || {};
+    // opcode 2 = binaria (WebcastPushFrame). El texto/ping/pong no interesa.
+    // Para binarias, payloadData YA viene en base64: justo lo que espera VeTube.
+    if (fr.opcode !== 2) return;
+    if (typeof fr.payloadData === "string" && fr.payloadData) {
+      acumularTrama(claveDbg(tabId, params.requestId), info, fr.payloadData);
+    }
+  } else if (metodo === "Network.webSocketClosed") {
+    const mapa = wsPorTab.get(tabId);
+    const info = mapa && mapa.get(params.requestId);
+    if (info) {
+      const clave = claveDbg(tabId, params.requestId);
+      descargarLote(clave);
+      if (info.esWebcast) {
+        encolar(function () {
+          return cerrarSesion(clave, info);
+        });
+      }
+      mapa.delete(params.requestId);
+    }
+  }
+});
+
+chrome.debugger.onDetach.addListener(function (source, reason) {
+  if (source.tabId == null) return;
+  adjuntas.delete(source.tabId);
+  limpiarSesionesDeTab(source.tabId);
+  encolar(async function () {
+    const st = await cargarEstado();
+    st.diag.adjuntas = adjuntas.size;
+    st.diag.ultimoError = "depurador desconectado: " + (reason || "?");
+    await guardarEstado();
+  });
+});
+
+chrome.tabs.onRemoved.addListener(function (tabId) {
+  adjuntas.delete(tabId);
+  limpiarSesionesDeTab(tabId);
+  encolar(async function () {
+    const st = await cargarEstado();
+    if (st.paginas[tabId]) delete st.paginas[tabId];
+    st.diag.adjuntas = adjuntas.size;
+    await guardarEstado();
+  });
+});
+
+// ---------------------------------------------------------------------
+// Consultas del popup
+// ---------------------------------------------------------------------
+chrome.runtime.onMessage.addListener(function (msg, sender, responder) {
+  if (!msg || msg.tipo !== "estado") return false;
+  (async function () {
+    const st = await cargarEstado();
+    const salud = await comprobarSalud();
+    st.diag.adjuntas = adjuntas.size;
+    await guardarEstado();
+    const sesiones = Object.keys(st.sesiones).map(function (k) {
+      return st.sesiones[k];
+    });
+    const paginas = Object.keys(st.paginas).map(function (k) {
+      return st.paginas[k];
+    });
+    responder({
+      vetube: salud,
+      versionEsperada: VERSION_CONTRATO,
+      sesiones: sesiones,
+      paginas: paginas,
+      contadores: st.contadores,
+      diag: st.diag || {},
+      ahoraMs: Date.now(),
+    });
+  })();
+  return true; // respuesta asíncrona
+});
+
+console.log("[VeTube] service worker arrancado (captura por depurador)");

--- a/interceptor_extension/logica.js
+++ b/interceptor_extension/logica.js
@@ -1,0 +1,339 @@
+// Lógica pura del puente: nada de aquí toca el DOM, ni chrome.*, ni la red.
+//
+// ¿Por qué un archivo aparte? Porque la parte que más fácil se rompe en
+// silencio (qué websocket se acepta, cómo se agrupan las tramas, cómo avanza
+// el contador seq) es justo la que no se puede probar dentro de Chrome sin
+// abrir un directo real. Sacándola aquí, `pruebas/pruebas.js` la ejercita con
+// Node en un segundo y sin navegador. Eso es parte del diseño, no un extra.
+//
+// El mismo archivo se carga en tres sitios distintos:
+//   - mundo MAIN de la página (inject.js)      -> vía globalThis.__vetubeLogica
+//   - mundo aislado del content script         -> vía globalThis.__vetubeLogica
+//   - Node, en el banco de pruebas             -> vía module.exports
+"use strict";
+
+(function (raiz, fabrica) {
+  const api = fabrica();
+
+  // OJO: no se detecta Node con `typeof module === "object"`. La página de
+  // TikTok trae bundles que a veces definen un `module` global propio, y si
+  // nos colásemos por esa rama la API nunca quedaría publicada y inject.js se
+  // quedaría sin lógica. `process.versions.node` sí es exclusivo de Node.
+  const enNode =
+    typeof process !== "undefined" &&
+    !!(process.versions && process.versions.node);
+
+  if (enNode) {
+    module.exports = api;
+    return;
+  }
+
+  // No enumerable: en el mundo MAIN esto vive un instante en el `window` de la
+  // página (inject.js lo lee y lo borra acto seguido), así que cuanto menos
+  // visible sea para el código de TikTok, mejor.
+  try {
+    Object.defineProperty(raiz, "__vetubeLogica", {
+      value: api,
+      configurable: true,
+      enumerable: false,
+      writable: false,
+    });
+  } catch (e) {
+    raiz.__vetubeLogica = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  // ---------------------------------------------------------------------
+  // 1. Filtro de host
+  // ---------------------------------------------------------------------
+
+  // Dato de campo: el websocket del chat del directo es
+  //   wss://webcast-ws.tiktok.com/webcast/im/ws_proxy/ws_reuse_supplement/...
+  // y en la misma pestaña convive otro websocket SIN relación,
+  //   wss://im-ws-sg.tiktok.com/ws/v2   (mensajería privada).
+  // Un filtro laxo por "im" o por "ws" deja pasar el segundo, que no trae
+  // chat del directo y sólo ensuciaría a VeTube. Por eso el filtro es por
+  // HOST y exige que la primera etiqueta del dominio empiece por "webcast".
+  //
+  // Se acepta cualquier `webcast*.tiktok.com` (TikTok reparte por región:
+  // webcast16-ws-useast1a.tiktok.com y parecidos) pero nada más.
+  function esHostDeTikTok(host) {
+    const h = String(host || "").toLowerCase();
+    // Comprobación de sufijo de verdad: "evil-tiktok.com" no es tiktok.com.
+    return h === "tiktok.com" || h.endsWith(".tiktok.com");
+  }
+
+  function esWebSocketDelWebcast(url) {
+    let u;
+    try {
+      u = new URL(String(url));
+    } catch (e) {
+      return false;
+    }
+    if (u.protocol !== "wss:" && u.protocol !== "ws:") return false;
+    if (!esHostDeTikTok(u.hostname)) return false;
+    const primeraEtiqueta = u.hostname.toLowerCase().split(".")[0];
+    return primeraEtiqueta.indexOf("webcast") === 0;
+  }
+
+  // Señal secundaria, sólo para diagnóstico en el popup: la ruta del webcast.
+  // NO se usa para aceptar o descartar, porque TikTok ya cambió la ruta una vez
+  // (/webcast/im/ws/ -> /webcast/im/ws_proxy/ws_reuse_supplement/) y no quiero
+  // que un cambio así deje a la usuaria sin chat.
+  function esRutaDeWebcast(url) {
+    try {
+      return new URL(String(url)).pathname.indexOf("/webcast/im/ws") === 0;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // 2. Identidad del directo
+  // ---------------------------------------------------------------------
+
+  function sacarRoomId(url) {
+    try {
+      return new URL(String(url)).searchParams.get("room_id") || "";
+    } catch (e) {
+      return "";
+    }
+  }
+
+  // El room_id de la query es el de la sala INICIAL: como la conexión se
+  // reutiliza entre salas (ws_reuse_supplement), después de cambiar de directo
+  // queda desactualizado. El @usuario de la ruta, en cambio, siempre es el de
+  // la sala que se está viendo ahora, así que es el dato autoritativo.
+  function sacarUniqueIdDeRuta(pathname) {
+    const m = String(pathname || "").match(/\/@([^/?#]+)/);
+    if (!m) return "";
+    try {
+      return decodeURIComponent(m[1]);
+    } catch (e) {
+      return m[1];
+    }
+  }
+
+  function esRutaDeDirecto(pathname) {
+    return /\/@[^/?#]+\/live/.test(String(pathname || ""));
+  }
+
+  // ---------------------------------------------------------------------
+  // 3. Base64
+  // ---------------------------------------------------------------------
+  // Las tramas llegan como Blob (binaryType "blob"); se pasan a ArrayBuffer y
+  // de ahí a base64 porque chrome.runtime.sendMessage y los puertos serializan
+  // como JSON: un ArrayBuffer o un Uint8Array NO sobreviven ese salto (llegan
+  // como {} o como un objeto con claves numéricas). base64 es el único formato
+  // que cruza intacto y que además es exactamente lo que pide el contrato.
+
+  const TROZO = 0x8000; // fromCharCode.apply se ahoga con arrays enormes
+
+  function arrayBufferABase64(buf) {
+    const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let binario = "";
+    for (let i = 0; i < bytes.length; i += TROZO) {
+      binario += String.fromCharCode.apply(null, bytes.subarray(i, i + TROZO));
+    }
+    return btoa(binario);
+  }
+
+  // Sólo la usan las pruebas (y el diagnóstico), pero vive aquí para que la ida
+  // y la vuelta se prueben contra la misma implementación.
+  function base64AUint8(texto) {
+    const binario = atob(String(texto));
+    const salida = new Uint8Array(binario.length);
+    for (let i = 0; i < binario.length; i++) salida[i] = binario.charCodeAt(i);
+    return salida;
+  }
+
+  // ---------------------------------------------------------------------
+  // 4. Agrupador de tramas (lotes)
+  // ---------------------------------------------------------------------
+  // Dato de campo: 24 tramas en ~10 s en un directo mediano, de 132 a 6423
+  // bytes. Un POST por trama serían ~2,4 peticiones por segundo a VeTube y un
+  // ida y vuelta de puerto por cada una: derroche puro. Se agrupa por tiempo
+  // (maxMs) y por cantidad (maxTramas), lo que llegue antes.
+  //
+  // Los temporizadores se inyectan para que las pruebas puedan usar un reloj
+  // falso y no depender de esperas reales.
+  function crearAgrupador(opciones) {
+    const cfg = Object.assign(
+      {
+        maxTramas: 20, // descarga al juntar esta cantidad
+        maxMs: 250, // ...o al pasar este tiempo desde la primera trama
+        maxTramasBuffer: 600, // tope duro de memoria (cantidad)
+        maxBytesBuffer: 2 * 1024 * 1024, // tope duro de memoria (bytes de base64)
+        alDescargar: function () {},
+        alDescartar: function () {},
+        programar: function (fn, ms) {
+          return setTimeout(fn, ms);
+        },
+        cancelar: function (id) {
+          clearTimeout(id);
+        },
+      },
+      opciones || {}
+    );
+
+    let buffer = [];
+    let bytes = 0;
+    let temporizador = null;
+    let descartadas = 0;
+    let recibidas = 0;
+
+    function pararTemporizador() {
+      if (temporizador !== null) {
+        cfg.cancelar(temporizador);
+        temporizador = null;
+      }
+    }
+
+    // Si el buffer se pasa del tope se tiran las tramas MÁS VIEJAS. Para un
+    // lector de chat en vivo lo que importa es lo que se está diciendo ahora:
+    // guardar lo viejo sólo alarga el retraso hasta hacerlo inservible.
+    function podar() {
+      let tiradas = 0;
+      while (
+        buffer.length > cfg.maxTramasBuffer ||
+        (bytes > cfg.maxBytesBuffer && buffer.length > 0)
+      ) {
+        const vieja = buffer.shift();
+        bytes -= vieja.length;
+        tiradas++;
+      }
+      if (tiradas > 0) {
+        descartadas += tiradas;
+        cfg.alDescartar(tiradas, descartadas);
+      }
+      return tiradas;
+    }
+
+    function descargar() {
+      pararTemporizador();
+      if (buffer.length === 0) return null;
+      const lote = buffer;
+      buffer = [];
+      bytes = 0;
+      cfg.alDescargar(lote);
+      return lote;
+    }
+
+    function agregar(tramaB64) {
+      if (typeof tramaB64 !== "string" || tramaB64.length === 0) return false;
+      recibidas++;
+      buffer.push(tramaB64);
+      bytes += tramaB64.length;
+      podar();
+
+      if (buffer.length >= cfg.maxTramas) {
+        descargar();
+      } else if (temporizador === null && buffer.length > 0) {
+        temporizador = cfg.programar(function () {
+          temporizador = null;
+          descargar();
+        }, cfg.maxMs);
+      }
+      return true;
+    }
+
+    // Al devolver tramas que no se pudieron entregar (puerto caído, VeTube sin
+    // responder) se meten POR DELANTE para no alterar el orden de llegada: el
+    // lado Python parsea protobuf y el orden importa.
+    function devolver(lote) {
+      if (!lote || lote.length === 0) return;
+      buffer = lote.concat(buffer);
+      for (let i = 0; i < lote.length; i++) bytes += lote[i].length;
+      podar();
+    }
+
+    function estado() {
+      return {
+        enBuffer: buffer.length,
+        bytes: bytes,
+        descartadas: descartadas,
+        recibidas: recibidas,
+      };
+    }
+
+    function vaciar() {
+      pararTemporizador();
+      buffer = [];
+      bytes = 0;
+    }
+
+    return {
+      agregar: agregar,
+      descargar: descargar,
+      devolver: devolver,
+      estado: estado,
+      vaciar: vaciar,
+      config: cfg,
+    };
+  }
+
+  // ---------------------------------------------------------------------
+  // 5. Contador seq
+  // ---------------------------------------------------------------------
+  // El contrato pide un entero monotónico POR SESIÓN. Aquí "seq" numera LOTES,
+  // no tramas: con `tramas` siendo una lista, un seq por trama sería ambiguo
+  // (¿la primera?, ¿la última?), mientras que numerar el lote le deja al lado
+  // Python una comprobación trivial: si el seq que llega no es el anterior + 1,
+  // se perdió un lote.
+  //
+  // Una "sesión" es (socket interceptado + @usuario que se está viendo). Como
+  // el socket se reutiliza entre salas, al cambiar de directo se cierra una
+  // sesión y se abre otra, y el contador vuelve a 0 para la nueva.
+  function crearContadorSeq(inicial) {
+    let n = Number(inicial) || 0;
+    return {
+      siguiente: function () {
+        return n++;
+      },
+      valor: function () {
+        return n;
+      },
+      fijar: function (v) {
+        n = Number(v) || 0;
+      },
+    };
+  }
+
+  function claveDeSesion(idSocket, uniqueId) {
+    return String(idSocket || "?") + "|" + String(uniqueId || "");
+  }
+
+  // ---------------------------------------------------------------------
+  // 6. Cookies
+  // ---------------------------------------------------------------------
+  // Lista blanca cerrada. Está comprobado en campo que con user_is_login=false
+  // el directo y su chat funcionan igual, así que no hay ningún motivo para
+  // que `sessionid` (la llave completa de la cuenta) salga del navegador.
+  const COOKIES_PERMITIDAS = ["ttwid", "tt-target-idc"];
+
+  function filtrarCookies(listaDeCookies) {
+    const salida = {};
+    const lista = listaDeCookies || [];
+    for (let i = 0; i < lista.length; i++) {
+      const c = lista[i];
+      if (!c || !c.name) continue;
+      if (COOKIES_PERMITIDAS.indexOf(c.name) !== -1) salida[c.name] = c.value;
+    }
+    return salida;
+  }
+
+  return {
+    esWebSocketDelWebcast: esWebSocketDelWebcast,
+    esRutaDeWebcast: esRutaDeWebcast,
+    esHostDeTikTok: esHostDeTikTok,
+    sacarRoomId: sacarRoomId,
+    sacarUniqueIdDeRuta: sacarUniqueIdDeRuta,
+    esRutaDeDirecto: esRutaDeDirecto,
+    arrayBufferABase64: arrayBufferABase64,
+    base64AUint8: base64AUint8,
+    crearAgrupador: crearAgrupador,
+    crearContadorSeq: crearContadorSeq,
+    claveDeSesion: claveDeSesion,
+    filtrarCookies: filtrarCookies,
+    COOKIES_PERMITIDAS: COOKIES_PERMITIDAS,
+  };
+});

--- a/interceptor_extension/manifest.json
+++ b/interceptor_extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "VeTube - puente del chat de TikTok Live",
+  "version": "0.4.0",
+  "description": "Lee las tramas del chat del directo con la API de depuracion de Chrome (inmune a la CSP de TikTok) y se las pasa a VeTube por 127.0.0.1. No recalcula firmas ni manda tu sesion.",
+  "minimum_chrome_version": "116",
+  "permissions": [
+    "storage",
+    "debugger"
+  ],
+  "host_permissions": [
+    "https://*.tiktok.com/*",
+    "http://127.0.0.1:8790/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "VeTube: estado del puente"
+  }
+}

--- a/interceptor_extension/popup.html
+++ b/interceptor_extension/popup.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>VeTube: estado del puente</title>
+    <style>
+      /* Colores en variables y con las dos combinaciones definidas: la usuaria
+         usa lector de pantalla, pero el popup lo puede mirar cualquiera y el
+         contraste no se negocia. Ningún estado se comunica SÓLO con color:
+         todos van escritos con palabras. */
+      :root {
+        color-scheme: light dark;
+        --fondo: #ffffff;
+        --texto: #14161a;
+        --tenue: #4a4f57;
+        --borde: #9aa0a8;
+        --foco: #0b57d0;
+        --aviso-fondo: #fff4e5;
+        --aviso-borde: #8a5300;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --fondo: #16181d;
+          --texto: #f2f4f7;
+          --tenue: #c2c8d0;
+          --borde: #6b7280;
+          --foco: #8ab4f8;
+          --aviso-fondo: #33270f;
+          --aviso-borde: #f0b357;
+        }
+      }
+
+      body {
+        width: 360px;
+        margin: 0;
+        padding: 12px 14px 16px;
+        background: var(--fondo);
+        color: var(--texto);
+        font: 15px/1.5 system-ui, "Segoe UI", sans-serif;
+      }
+
+      h1 {
+        font-size: 17px;
+        margin: 0 0 8px;
+      }
+      h2 {
+        font-size: 15px;
+        margin: 16px 0 6px;
+      }
+
+      #resumen {
+        margin: 0 0 8px;
+        padding: 8px 10px;
+        border: 1px solid var(--borde);
+        border-radius: 6px;
+        font-weight: 600;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 20px;
+      }
+      li {
+        margin-bottom: 4px;
+      }
+      .dato {
+        color: var(--tenue);
+      }
+
+      #aviso-recarga {
+        margin-top: 14px;
+        padding: 10px;
+        background: var(--aviso-fondo);
+        border: 2px solid var(--aviso-borde);
+        border-radius: 6px;
+      }
+      #aviso-recarga h2 {
+        margin-top: 0;
+      }
+      #aviso-recarga p {
+        margin: 0 0 8px;
+      }
+
+      button {
+        font: inherit;
+        min-height: 36px;
+        padding: 6px 12px;
+        margin: 4px 6px 4px 0;
+        color: var(--texto);
+        background: transparent;
+        border: 2px solid var(--borde);
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      button:hover {
+        border-color: var(--texto);
+      }
+      /* Foco visible y grueso: sin esto, moverse con teclado es a ciegas de
+         verdad para quien mira la pantalla. */
+      :focus-visible {
+        outline: 3px solid var(--foco);
+        outline-offset: 2px;
+      }
+
+      label {
+        display: block;
+        margin-bottom: 4px;
+      }
+      textarea {
+        width: 100%;
+        box-sizing: border-box;
+        font: 13px/1.4 ui-monospace, Consolas, monospace;
+        color: var(--texto);
+        background: var(--fondo);
+        border: 1px solid var(--borde);
+        border-radius: 6px;
+        padding: 6px;
+        resize: vertical;
+      }
+
+      p.nota {
+        color: var(--tenue);
+        margin: 8px 0 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>VeTube: estado del puente</h1>
+
+    <!-- role="status" (región viva educada): se anuncia solo al abrir el popup
+         y cada vez que se pulsa "Actualizar estado". No se refresca con un
+         temporizador a propósito: una región viva que cambia cada dos segundos
+         no para de hablar y vuelve el popup inservible con NVDA. -->
+    <p id="resumen" role="status">Consultando el estado…</p>
+
+    <h2>Detalle</h2>
+    <ul id="detalle">
+      <li>Cargando…</li>
+    </ul>
+
+    <div id="aviso-recarga" hidden>
+      <h2>Hace falta recargar el directo</h2>
+      <p id="texto-aviso"></p>
+      <button id="recargar" type="button">Recargar la página del directo</button>
+    </div>
+
+    <h2>Acciones</h2>
+    <button id="actualizar" type="button">Actualizar estado</button>
+
+    <h2>Diagnóstico</h2>
+    <label for="diag">
+      Texto de diagnóstico, sin datos privados (se puede copiar con Control+A y
+      Control+C)
+    </label>
+    <textarea id="diag" readonly rows="7"></textarea>
+    <button id="copiar" type="button">Copiar diagnóstico</button>
+
+    <p class="nota">
+      Esta extensión sólo habla con 127.0.0.1 en el puerto 8790. Nunca envía la
+      cookie de sesión.
+    </p>
+
+    <script src="logica.js"></script>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/interceptor_extension/popup.js
+++ b/interceptor_extension/popup.js
@@ -1,0 +1,258 @@
+// Popup de estado. Pensado para leerse con NVDA: todo lo que importa está
+// escrito con palabras, no con colores ni con iconos, y el resumen se anuncia
+// una sola vez (al abrir y al pulsar "Actualizar estado"), nunca en bucle.
+"use strict";
+
+const L = globalThis.__vetubeLogica;
+
+const $ = function (id) {
+  return document.getElementById(id);
+};
+
+// Anunciar en la región viva. Se vacía y se vuelve a poner con un respiro para
+// forzar una mutación: si el texto nuevo fuese idéntico al viejo, algunos
+// lectores no dirían nada y la usuaria se quedaría sin saber si el botón hizo
+// algo o no.
+function anunciar(texto) {
+  const el = $("resumen");
+  el.textContent = "";
+  setTimeout(function () {
+    el.textContent = texto;
+  }, 60);
+}
+
+function hace(ahoraMs, cuandoMs) {
+  if (!cuandoMs) return null;
+  const s = Math.max(0, Math.round((ahoraMs - cuandoMs) / 1000));
+  if (s < 60) return "hace " + s + " segundo" + (s === 1 ? "" : "s");
+  const m = Math.round(s / 60);
+  return "hace " + m + " minuto" + (m === 1 ? "" : "s");
+}
+
+function pintarLista(lineas) {
+  const ul = $("detalle");
+  ul.textContent = "";
+  lineas.forEach(function (linea) {
+    const li = document.createElement("li");
+    li.textContent = linea;
+    ul.appendChild(li);
+  });
+}
+
+async function pestanaActiva() {
+  try {
+    const pestanas = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    return pestanas && pestanas[0] ? pestanas[0] : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+// La url de la pestaña sólo llega si la extensión tiene permiso de host para
+// ella; como sólo lo pedimos para tiktok.com, en cualquier otra página esto
+// devuelve null y el popup no se entera de por dónde anda la usuaria. Es la
+// consecuencia buena de pedir permisos mínimos.
+function rutaDePestana(pestana) {
+  if (!pestana || !pestana.url) return null;
+  try {
+    return new URL(pestana.url).pathname;
+  } catch (e) {
+    return null;
+  }
+}
+
+async function refrescar(porPeticion) {
+  let est = null;
+  try {
+    est = await chrome.runtime.sendMessage({ tipo: "estado" });
+  } catch (e) {
+    pintarLista(["No se pudo hablar con la extensión: " + String(e)]);
+    anunciar("Error: la extensión no responde. Probá a recargarla desde chrome://extensions.");
+    return;
+  }
+  if (!est) {
+    pintarLista(["La extensión no devolvió estado."]);
+    anunciar("Error: la extensión no devolvió estado.");
+    return;
+  }
+
+  const pestana = await pestanaActiva();
+  const ruta = rutaDePestana(pestana);
+  const enDirecto = ruta ? L.esRutaDeDirecto(ruta) : false;
+  const usuarioDeLaPestana = ruta ? L.sacarUniqueIdDeRuta(ruta) : "";
+
+  const sesiones = est.sesiones || [];
+  const enganchado = sesiones.length > 0;
+  const c = est.contadores || {};
+  const v = est.vetube || {};
+
+  // ---- detalle -------------------------------------------------------
+  const lineas = [];
+
+  if (v.ok) {
+    if (v.version === est.versionEsperada) {
+      lineas.push("VeTube escuchando: sí, en el puerto 8790 (contrato versión " + v.version + ").");
+    } else {
+      lineas.push(
+        "VeTube escuchando: sí, pero con el contrato versión " +
+          (v.version || "desconocida") +
+          " y esta extensión habla la " +
+          est.versionEsperada +
+          ". Actualizá VeTube o la extensión."
+      );
+    }
+  } else {
+    lineas.push(
+      "VeTube escuchando: no. " +
+        (v.ultimoError ? "Detalle: " + v.ultimoError + "." : "") +
+        " Abrí VeTube y poné en marcha el directo de TikTok."
+    );
+  }
+
+  if (enganchado) {
+    const nombres = sesiones
+      .map(function (s) {
+        return "@" + (s.unique_id || "(sin usuario)");
+      })
+      .join(", ");
+    lineas.push("Websocket del webcast: enganchado a " + nombres + ".");
+  } else {
+    lineas.push("Websocket del webcast: no enganchado a ningún directo.");
+  }
+
+  lineas.push("Tramas enviadas a VeTube: " + (c.tramasEnviadas || 0) + ".");
+  lineas.push("Lotes enviados: " + (c.lotesEnviados || 0) + ".");
+  lineas.push(
+    "Tramas descartadas: " +
+      (c.tramasDescartadas || 0) +
+      (c.tramasDescartadas ? " (VeTube no las recibió)." : ".")
+  );
+
+  const cuando = hace(est.ahoraMs, c.ultimaTramaMs);
+  lineas.push("Última trama enviada: " + (cuando ? cuando + "." : "todavía ninguna."));
+
+  const dg0 = est.diag || {};
+  lineas.push(
+    "Captura por depurador: " + (dg0.adjuntas || 0) + " pestana(s) de TikTok enganchada(s). " +
+      "Websockets del webcast vistos: " + (dg0.wsWebcast || 0) + ". " +
+      "Tramas del chat leidas: " + (dg0.framesWebcast || 0) + "." +
+      (dg0.ultimoError ? " Ultimo aviso del depurador: " + dg0.ultimoError + "." : "")
+  );
+
+  pintarLista(lineas);
+
+  // ---- aviso de recarga ---------------------------------------------
+  // Caso 5(a): la conexión se reutiliza entre salas, así que si la extensión
+  // se cargó (o se actualizó) con el directo ya abierto, ese socket ya existía
+  // y el envoltorio no llegó a verlo nacer. No hay forma de engancharse a
+  // posteriori: sólo recargar.
+  const yaEnganchadaEsta = sesiones.some(function (s) {
+    return s.unique_id === usuarioDeLaPestana;
+  });
+  const hayQueRecargar = enDirecto && !yaEnganchadaEsta;
+
+  $("aviso-recarga").hidden = !hayQueRecargar;
+  if (hayQueRecargar) {
+    $("texto-aviso").textContent =
+      "Estás en el directo de @" +
+      (usuarioDeLaPestana || "este usuario") +
+      ", pero la extensión no llegó a ver abrirse su websocket. Pasa cuando el " +
+      "directo ya estaba abierto antes de que la extensión se enganchara. " +
+      "Recargá la página del directo y volverá a engancharse.";
+  }
+
+  // ---- resumen hablado ----------------------------------------------
+  let resumen;
+  if (!v.ok) {
+    resumen = "VeTube no responde en el puerto 8790. Abrilo y volvé a comprobar.";
+  } else if (hayQueRecargar) {
+    resumen = "Hace falta recargar la página del directo para engancharse.";
+  } else if (!enganchado) {
+    resumen = "VeTube escucha. Todavía no hay ningún directo enganchado: abrí un directo de TikTok.";
+  } else {
+    resumen =
+      "Todo en marcha. Enganchado a @" +
+      (sesiones[0].unique_id || "un directo") +
+      ", " +
+      (c.tramasEnviadas || 0) +
+      " tramas enviadas.";
+  }
+  anunciar(porPeticion ? "Estado actualizado. " + resumen : resumen);
+
+  // ---- diagnóstico ---------------------------------------------------
+  // Sin la ws_url completa: lleva la firma X-Bogus. Van los nombres y la
+  // forma, que es lo que sirve para depurar y lo que se puede pegar entero en
+  // un informe sin regalar nada.
+  const diag = [
+    "VeTube, puente del chat de TikTok",
+    "VeTube escuchando: " + (v.ok ? "sí" : "no") + " (versión " + (v.version || 0) + ", esperada " + est.versionEsperada + ")",
+    "Último error de red: " + (v.ultimoError || "ninguno"),
+    "Sesiones abiertas: " + sesiones.length,
+  ];
+  sesiones.forEach(function (s) {
+    let host = "?";
+    let ruta_ws = "?";
+    let params = "?";
+    try {
+      const u = new URL(s.ws_url);
+      host = u.hostname;
+      ruta_ws = u.pathname;
+      params = Array.from(u.searchParams.keys()).sort().join(",");
+    } catch (e) {
+      /* sin url utilizable */
+    }
+    diag.push("  @" + s.unique_id + " room_id=" + (s.room_id || "?"));
+    diag.push("    host=" + host + " ruta=" + ruta_ws);
+    diag.push("    params=" + params);
+  });
+  diag.push("Tramas enviadas: " + (c.tramasEnviadas || 0));
+  diag.push("Lotes enviados: " + (c.lotesEnviados || 0));
+  diag.push("Lotes fallidos: " + (c.lotesFallidos || 0));
+  const dgx = est.diag || {};
+  diag.push("Captura: por depurador (chrome.debugger)");
+  diag.push("Pestanas enganchadas: " + (dgx.adjuntas || 0));
+  diag.push("Websockets del webcast vistos: " + (dgx.wsWebcast || 0));
+  diag.push("Tramas del chat leidas: " + (dgx.framesWebcast || 0));
+  diag.push("Ultimo aviso del depurador: " + (dgx.ultimoError || "ninguno"));
+  diag.push("Tramas descartadas: " + (c.tramasDescartadas || 0));
+  diag.push("Pestaña actual es un directo: " + (enDirecto ? "sí" : "no"));
+  $("diag").value = diag.join("\n");
+}
+
+$("actualizar").addEventListener("click", function () {
+  refrescar(true);
+});
+
+$("recargar").addEventListener("click", async function () {
+  const pestana = await pestanaActiva();
+  if (!pestana) {
+    anunciar("No se encontró la pestaña activa.");
+    return;
+  }
+  try {
+    await chrome.tabs.reload(pestana.id);
+    window.close(); // el popup ya no pinta nada: la página se está recargando
+  } catch (e) {
+    anunciar("No se pudo recargar la pestaña: " + String(e));
+  }
+});
+
+$("copiar").addEventListener("click", async function () {
+  try {
+    await navigator.clipboard.writeText($("diag").value);
+    anunciar("Diagnóstico copiado al portapapeles.");
+  } catch (e) {
+    // Plan B que no depende de ningún permiso: el texto ya está en un cuadro
+    // de sólo lectura, así que se le lleva el foco y se selecciona entero.
+    $("diag").focus();
+    $("diag").select();
+    anunciar(
+      "No se pudo copiar automáticamente. El diagnóstico está seleccionado: pulsá Control+C."
+    );
+  }
+});
+
+refrescar(false);

--- a/interceptor_extension/pruebas/pruebas.js
+++ b/interceptor_extension/pruebas/pruebas.js
@@ -1,0 +1,661 @@
+// Banco de pruebas de la lógica pura del puente. Se ejecuta SIN Chrome:
+//
+//     node pruebas/pruebas.js
+//
+// Cubre lo que se rompe en silencio y no se ve hasta que la usuaria está
+// delante de un directo: el filtro de host (que el websocket de la mensajería
+// privada NO se cuele), el ida y vuelta a base64, el agrupado en lotes con su
+// tope de memoria, el contador seq y la lista blanca de cookies.
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const assert = require("assert");
+
+const RAIZ = path.join(__dirname, "..");
+const L = require(path.join(RAIZ, "logica.js"));
+
+// ---------------------------------------------------------------------
+// Corredor mínimo (nada de dependencias: la extensión no tiene build)
+// ---------------------------------------------------------------------
+let pasadas = 0;
+const fallos = [];
+
+function prueba(nombre, fn) {
+  try {
+    fn();
+    pasadas++;
+    console.log("  OK   " + nombre);
+  } catch (e) {
+    fallos.push({ nombre: nombre, error: e });
+    console.log("  FALLA " + nombre);
+    console.log("        " + (e && e.message ? e.message : e));
+  }
+}
+
+function grupo(titulo) {
+  console.log("\n" + titulo);
+}
+
+// Reloj falso: el agrupador recibe sus temporizadores por parámetro justo para
+// que aquí no haya que esperar de verdad ni un milisegundo.
+function crearReloj() {
+  let ahora = 0;
+  let siguienteId = 0;
+  const tareas = new Map();
+  return {
+    programar: function (fn, ms) {
+      const id = ++siguienteId;
+      tareas.set(id, { fn: fn, cuando: ahora + ms });
+      return id;
+    },
+    cancelar: function (id) {
+      tareas.delete(id);
+    },
+    avanzar: function (ms) {
+      ahora += ms;
+      const vencidas = Array.from(tareas.entries())
+        .filter(function (par) {
+          return par[1].cuando <= ahora;
+        })
+        .sort(function (a, b) {
+          return a[1].cuando - b[1].cuando;
+        });
+      vencidas.forEach(function (par) {
+        tareas.delete(par[0]);
+        par[1].fn();
+      });
+    },
+    pendientes: function () {
+      return tareas.size;
+    },
+  };
+}
+
+// =====================================================================
+grupo("1. Filtro de host del websocket del webcast");
+
+const WS_WEBCAST =
+  "wss://webcast-ws.tiktok.com/webcast/im/ws_proxy/ws_reuse_supplement/" +
+  "?room_id=7412345678901234567&compress=gzip&identity=audience&ws_direct=1&X-Bogus=DFSzabc";
+const WS_MENSAJERIA = "wss://im-ws-sg.tiktok.com/ws/v2?aid=1988&device_id=123";
+
+prueba("acepta el websocket real del webcast", function () {
+  assert.strictEqual(L.esWebSocketDelWebcast(WS_WEBCAST), true);
+});
+
+prueba("acepta la ruta vieja /webcast/im/ws/", function () {
+  assert.strictEqual(
+    L.esWebSocketDelWebcast("wss://webcast-ws.tiktok.com/webcast/im/ws/?room_id=1"),
+    true
+  );
+});
+
+prueba("acepta hosts regionales tipo webcast16-ws-useast1a", function () {
+  assert.strictEqual(
+    L.esWebSocketDelWebcast("wss://webcast16-ws-useast1a.tiktok.com/webcast/im/ws/"),
+    true
+  );
+});
+
+prueba("DESCARTA im-ws-sg (mensajería privada), que es el que se cuela", function () {
+  assert.strictEqual(L.esWebSocketDelWebcast(WS_MENSAJERIA), false);
+});
+
+prueba("un filtro laxo por 'im' o 'ws' dejaría pasar im-ws-sg: el nuestro no", function () {
+  // Demostración, no adorno: se reconstruye el filtro ingenuo para dejar por
+  // escrito que sí se traga la mensajería privada, y que el nuestro no.
+  const ingenuo = function (u) {
+    return /tiktok\.com/i.test(u) && /(im|ws)/i.test(u);
+  };
+  assert.strictEqual(ingenuo(WS_MENSAJERIA), true, "el ingenuo sí lo deja pasar");
+  assert.strictEqual(L.esWebSocketDelWebcast(WS_MENSAJERIA), false);
+});
+
+prueba("el filtro del prototipo anterior se cuela con un ?from=webcast; el nuestro no", function () {
+  // El filtro viejo miraba la URL entera, así que cualquier parámetro de la
+  // query con la palabra "webcast" lo convencía. Mirando el HOST eso ya no
+  // puede pasar.
+  const viejo = function (u) {
+    return /tiktok\.com/i.test(u) && /webcast|\/im\/ws/i.test(u);
+  };
+  const trampa = "wss://im-ws-sg.tiktok.com/ws/v2?aid=1988&from=webcast";
+  assert.strictEqual(viejo(trampa), true, "el filtro viejo se lo traga");
+  assert.strictEqual(L.esWebSocketDelWebcast(trampa), false);
+});
+
+prueba("descarta im-ws-sg.tiktokv.com (otro dominio de TikTok)", function () {
+  assert.strictEqual(L.esWebSocketDelWebcast("wss://im-ws-sg.tiktokv.com/ws/v2"), false);
+});
+
+prueba("descarta el truco del sufijo: webcast-ws.evil-tiktok.com", function () {
+  assert.strictEqual(
+    L.esWebSocketDelWebcast("wss://webcast-ws.evil-tiktok.com/webcast/im/ws/"),
+    false
+  );
+});
+
+prueba("descarta hosts que no empiezan por 'webcast'", function () {
+  assert.strictEqual(L.esWebSocketDelWebcast("wss://ws.tiktok.com/webcast/im/ws/"), false);
+  assert.strictEqual(L.esWebSocketDelWebcast("wss://mywebcast.tiktok.com/webcast/im/ws/"), false);
+});
+
+prueba("descarta esquemas que no son ws/wss", function () {
+  assert.strictEqual(
+    L.esWebSocketDelWebcast("https://webcast-ws.tiktok.com/webcast/im/ws/"),
+    false
+  );
+});
+
+prueba("no revienta con basura", function () {
+  [null, undefined, "", "no una url", 42, {}].forEach(function (v) {
+    assert.strictEqual(L.esWebSocketDelWebcast(v), false, "con " + String(v));
+  });
+});
+
+prueba("esRutaDeWebcast reconoce las dos rutas y descarta /ws/v2", function () {
+  assert.strictEqual(L.esRutaDeWebcast(WS_WEBCAST), true);
+  assert.strictEqual(L.esRutaDeWebcast("wss://webcast-ws.tiktok.com/webcast/im/ws/"), true);
+  assert.strictEqual(L.esRutaDeWebcast(WS_MENSAJERIA), false);
+});
+
+// =====================================================================
+grupo("2. Identidad del directo");
+
+prueba("saca el room_id de la query", function () {
+  assert.strictEqual(L.sacarRoomId(WS_WEBCAST), "7412345678901234567");
+  assert.strictEqual(L.sacarRoomId("wss://webcast-ws.tiktok.com/x"), "");
+  assert.strictEqual(L.sacarRoomId("basura"), "");
+});
+
+prueba("saca el @usuario de la ruta", function () {
+  assert.strictEqual(L.sacarUniqueIdDeRuta("/@usuario/live"), "usuario");
+  assert.strictEqual(L.sacarUniqueIdDeRuta("/@usuario.con.puntos/live"), "usuario.con.puntos");
+  assert.strictEqual(L.sacarUniqueIdDeRuta("/es/@otro/live"), "otro");
+  assert.strictEqual(L.sacarUniqueIdDeRuta("/@usuario"), "usuario");
+  assert.strictEqual(L.sacarUniqueIdDeRuta("/foryou"), "");
+  assert.strictEqual(L.sacarUniqueIdDeRuta(""), "");
+});
+
+prueba("reconoce si la ruta es la de un directo", function () {
+  assert.strictEqual(L.esRutaDeDirecto("/@usuario/live"), true);
+  assert.strictEqual(L.esRutaDeDirecto("/@usuario/video/123"), false);
+  assert.strictEqual(L.esRutaDeDirecto("/foryou"), false);
+});
+
+// =====================================================================
+grupo("3. Conversión a base64");
+
+prueba("ida y vuelta con el buffer vacío", function () {
+  const b64 = L.arrayBufferABase64(new Uint8Array(0));
+  assert.strictEqual(b64, "");
+  assert.strictEqual(L.base64AUint8(b64).length, 0);
+});
+
+prueba("ida y vuelta con los 256 valores de byte", function () {
+  const original = new Uint8Array(256);
+  for (let i = 0; i < 256; i++) original[i] = i;
+  const vuelta = L.base64AUint8(L.arrayBufferABase64(original));
+  assert.deepStrictEqual(Array.from(vuelta), Array.from(original));
+});
+
+prueba("coincide con Buffer.toString('base64') de Node (oráculo independiente)", function () {
+  const datos = Buffer.from("una trama WebcastPushFrame de mentira \x00\x01\xff", "binary");
+  const mio = L.arrayBufferABase64(new Uint8Array(datos));
+  assert.strictEqual(mio, datos.toString("base64"));
+});
+
+prueba("acepta ArrayBuffer y Uint8Array por igual", function () {
+  const u8 = new Uint8Array([1, 2, 3, 250, 251]);
+  assert.strictEqual(L.arrayBufferABase64(u8), L.arrayBufferABase64(u8.buffer));
+});
+
+prueba("aguanta el tamaño real máximo visto en campo (6423 bytes)", function () {
+  const grande = new Uint8Array(6423);
+  for (let i = 0; i < grande.length; i++) grande[i] = (i * 31) % 256;
+  const vuelta = L.base64AUint8(L.arrayBufferABase64(grande));
+  assert.strictEqual(vuelta.length, 6423);
+  assert.deepStrictEqual(Array.from(vuelta), Array.from(grande));
+});
+
+prueba("aguanta un buffer mayor que el trozo interno de 32768", function () {
+  const enorme = new Uint8Array(100000);
+  for (let i = 0; i < enorme.length; i++) enorme[i] = i % 256;
+  const vuelta = L.base64AUint8(L.arrayBufferABase64(enorme));
+  assert.strictEqual(vuelta.length, enorme.length);
+  assert.strictEqual(vuelta[99999], enorme[99999]);
+});
+
+// =====================================================================
+grupo("4. Agrupado en lotes");
+
+function agrupadorDePrueba(opciones) {
+  const reloj = crearReloj();
+  const lotes = [];
+  const descartes = [];
+  const ag = L.crearAgrupador(
+    Object.assign(
+      {
+        programar: reloj.programar,
+        cancelar: reloj.cancelar,
+        alDescargar: function (lote) {
+          lotes.push(lote);
+        },
+        alDescartar: function (tiradas, total) {
+          descartes.push({ tiradas: tiradas, total: total });
+        },
+      },
+      opciones
+    )
+  );
+  return { ag: ag, reloj: reloj, lotes: lotes, descartes: descartes };
+}
+
+prueba("descarga al llegar a maxTramas", function () {
+  const t = agrupadorDePrueba({ maxTramas: 3, maxMs: 250 });
+  t.ag.agregar("a");
+  t.ag.agregar("b");
+  assert.strictEqual(t.lotes.length, 0, "todavía no");
+  t.ag.agregar("c");
+  assert.strictEqual(t.lotes.length, 1);
+  assert.deepStrictEqual(t.lotes[0], ["a", "b", "c"]);
+});
+
+prueba("descarga al vencer maxMs aunque no se llene", function () {
+  const t = agrupadorDePrueba({ maxTramas: 20, maxMs: 250 });
+  t.ag.agregar("a");
+  t.ag.agregar("b");
+  t.reloj.avanzar(249);
+  assert.strictEqual(t.lotes.length, 0, "aún no vence");
+  t.reloj.avanzar(1);
+  assert.strictEqual(t.lotes.length, 1);
+  assert.deepStrictEqual(t.lotes[0], ["a", "b"]);
+});
+
+prueba("tras descargar por cantidad no queda un temporizador suelto", function () {
+  const t = agrupadorDePrueba({ maxTramas: 2, maxMs: 250 });
+  t.ag.agregar("a");
+  t.ag.agregar("b");
+  assert.strictEqual(t.lotes.length, 1);
+  t.reloj.avanzar(1000);
+  assert.strictEqual(t.lotes.length, 1, "no debe salir un lote vacío después");
+  assert.strictEqual(t.reloj.pendientes(), 0);
+});
+
+prueba("descargar() con el buffer vacío no llama al callback", function () {
+  const t = agrupadorDePrueba({ maxTramas: 5, maxMs: 250 });
+  assert.strictEqual(t.ag.descargar(), null);
+  assert.strictEqual(t.lotes.length, 0);
+});
+
+prueba("ignora tramas vacías o que no son texto", function () {
+  const t = agrupadorDePrueba({ maxTramas: 5, maxMs: 250 });
+  assert.strictEqual(t.ag.agregar(""), false);
+  assert.strictEqual(t.ag.agregar(null), false);
+  assert.strictEqual(t.ag.agregar(123), false);
+  assert.strictEqual(t.ag.estado().enBuffer, 0);
+});
+
+prueba("el tope de memoria por cantidad tira lo MÁS VIEJO y avisa", function () {
+  const t = agrupadorDePrueba({
+    maxTramas: 1000, // que no descargue por cantidad
+    maxMs: 999999,
+    maxTramasBuffer: 5,
+  });
+  for (let i = 0; i < 10; i++) t.ag.agregar("t" + i);
+  const est = t.ag.estado();
+  assert.strictEqual(est.enBuffer, 5);
+  assert.strictEqual(est.descartadas, 5);
+  assert.ok(t.descartes.length > 0, "tiene que avisar de los descartes");
+  const lote = t.ag.descargar();
+  assert.deepStrictEqual(lote, ["t5", "t6", "t7", "t8", "t9"], "se quedan las nuevas");
+});
+
+prueba("el tope de memoria por bytes también recorta", function () {
+  const t = agrupadorDePrueba({
+    maxTramas: 1000,
+    maxMs: 999999,
+    maxTramasBuffer: 10000,
+    maxBytesBuffer: 30,
+  });
+  for (let i = 0; i < 10; i++) t.ag.agregar("0123456789"); // 10 bytes cada una
+  assert.ok(t.ag.estado().bytes <= 30, "bytes=" + t.ag.estado().bytes);
+  assert.strictEqual(t.ag.estado().enBuffer, 3);
+  assert.strictEqual(t.ag.estado().descartadas, 7);
+});
+
+prueba("devolver() reinserta por delante y conserva el orden", function () {
+  const t = agrupadorDePrueba({ maxTramas: 1000, maxMs: 999999 });
+  t.ag.agregar("c");
+  t.ag.agregar("d");
+  t.ag.devolver(["a", "b"]);
+  assert.deepStrictEqual(t.ag.descargar(), ["a", "b", "c", "d"]);
+});
+
+prueba("el orden de llegada se conserva de punta a punta", function () {
+  const t = agrupadorDePrueba({ maxTramas: 4, maxMs: 250 });
+  const entrada = [];
+  for (let i = 0; i < 12; i++) {
+    entrada.push("trama-" + i);
+    t.ag.agregar("trama-" + i);
+  }
+  const salida = [].concat.apply([], t.lotes);
+  assert.deepStrictEqual(salida, entrada);
+});
+
+prueba("volumen real de campo: 24 tramas en 10 s salen en lotes y sin perder ninguna", function () {
+  // 24 tramas repartidas cada ~416 ms, con maxMs=250: cada trama vence su
+  // propio temporizador antes de que llegue la siguiente.
+  const t = agrupadorDePrueba({ maxTramas: 20, maxMs: 250 });
+  for (let i = 0; i < 24; i++) {
+    t.ag.agregar("t" + i);
+    t.reloj.avanzar(416);
+  }
+  const salida = [].concat.apply([], t.lotes);
+  assert.strictEqual(salida.length, 24, "no se pierde ninguna");
+  assert.strictEqual(t.ag.estado().descartadas, 0);
+  assert.ok(t.lotes.length <= 24 && t.lotes.length > 0);
+});
+
+prueba("una ráfaga corta se junta en un solo lote", function () {
+  const t = agrupadorDePrueba({ maxTramas: 20, maxMs: 250 });
+  for (let i = 0; i < 8; i++) {
+    t.ag.agregar("r" + i);
+    t.reloj.avanzar(10);
+  }
+  t.reloj.avanzar(250);
+  assert.strictEqual(t.lotes.length, 1, "una sola descarga para las 8");
+  assert.strictEqual(t.lotes[0].length, 8);
+});
+
+// =====================================================================
+grupo("5. Contador seq");
+
+prueba("empieza en 0 y sube de uno en uno", function () {
+  const s = L.crearContadorSeq();
+  assert.strictEqual(s.siguiente(), 0);
+  assert.strictEqual(s.siguiente(), 1);
+  assert.strictEqual(s.siguiente(), 2);
+  assert.strictEqual(s.valor(), 3);
+});
+
+prueba("se puede retomar desde un valor guardado (siesta del service worker)", function () {
+  const s = L.crearContadorSeq(41);
+  assert.strictEqual(s.siguiente(), 41);
+  s.fijar(100);
+  assert.strictEqual(s.siguiente(), 100);
+});
+
+prueba("nunca repite: 500 tiradas dan 500 valores distintos y crecientes", function () {
+  const s = L.crearContadorSeq();
+  let previo = -1;
+  for (let i = 0; i < 500; i++) {
+    const v = s.siguiente();
+    assert.strictEqual(v, previo + 1);
+    previo = v;
+  }
+});
+
+prueba("la clave de sesión separa dos salas del MISMO socket reutilizado", function () {
+  // Es el caso ws_reuse_supplement: el socket es el mismo, el directo no.
+  const a = L.claveDeSesion("ws1-abc", "primerdirecto");
+  const b = L.claveDeSesion("ws1-abc", "segundodirecto");
+  assert.notStrictEqual(a, b, "cada directo tiene que ser su propia sesión");
+  assert.strictEqual(a, L.claveDeSesion("ws1-abc", "primerdirecto"));
+});
+
+prueba("simulación: al cambiar de sala el seq de la nueva sesión arranca en 0", function () {
+  const seqs = {};
+  function siguienteSeq(clave) {
+    if (!seqs[clave]) seqs[clave] = L.crearContadorSeq();
+    return seqs[clave].siguiente();
+  }
+  const salaA = L.claveDeSesion("ws1", "unoa");
+  const salaB = L.claveDeSesion("ws1", "dosb");
+  assert.strictEqual(siguienteSeq(salaA), 0);
+  assert.strictEqual(siguienteSeq(salaA), 1);
+  assert.strictEqual(siguienteSeq(salaB), 0, "sala nueva, cuenta nueva");
+  assert.strictEqual(siguienteSeq(salaA), 2, "la vieja sigue donde estaba");
+});
+
+// =====================================================================
+grupo("6. Lista blanca de cookies (regla de seguridad)");
+
+const COOKIES_DE_MENTIRA = [
+  { name: "ttwid", value: "1%7Cabc" },
+  { name: "tt-target-idc", value: "useast2a" },
+  { name: "sessionid", value: "NO-DEBE-SALIR-NUNCA" },
+  { name: "sessionid_ss", value: "NO-DEBE-SALIR-NUNCA" },
+  { name: "sid_tt", value: "NO-DEBE-SALIR-NUNCA" },
+  { name: "sid_guard", value: "NO-DEBE-SALIR-NUNCA" },
+  { name: "uid_tt", value: "NO-DEBE-SALIR-NUNCA" },
+  { name: "msToken", value: "irrelevante" },
+  { name: "tt_csrf_token", value: "irrelevante" },
+];
+
+prueba("deja pasar exactamente ttwid y tt-target-idc", function () {
+  const salida = L.filtrarCookies(COOKIES_DE_MENTIRA);
+  assert.deepStrictEqual(Object.keys(salida).sort(), ["tt-target-idc", "ttwid"]);
+});
+
+prueba("NINGUNA credencial de sesión sale, ni por asomo", function () {
+  const salida = L.filtrarCookies(COOKIES_DE_MENTIRA);
+  const serializado = JSON.stringify(salida);
+  assert.ok(
+    serializado.indexOf("NO-DEBE-SALIR-NUNCA") === -1,
+    "se coló una credencial: " + serializado
+  );
+  ["sessionid", "sessionid_ss", "sid_tt", "sid_guard", "uid_tt"].forEach(function (n) {
+    assert.strictEqual(salida[n], undefined, n + " no puede estar");
+  });
+});
+
+prueba("la lista blanca en sí no contiene nada de sesión", function () {
+  assert.deepStrictEqual(L.COOKIES_PERMITIDAS.slice().sort(), ["tt-target-idc", "ttwid"]);
+  L.COOKIES_PERMITIDAS.forEach(function (n) {
+    assert.ok(!/session|sid|token|auth/i.test(n), "cookie sospechosa en la lista: " + n);
+  });
+});
+
+prueba("no revienta sin cookies", function () {
+  assert.deepStrictEqual(L.filtrarCookies([]), {});
+  assert.deepStrictEqual(L.filtrarCookies(null), {});
+});
+
+// =====================================================================
+grupo("7. Manifiesto y archivos");
+
+const manifiesto = JSON.parse(
+  fs.readFileSync(path.join(RAIZ, "manifest.json"), "utf8")
+);
+
+prueba("manifest.json es JSON válido y es Manifest V3", function () {
+  assert.strictEqual(manifiesto.manifest_version, 3);
+  assert.ok(manifiesto.name && manifiesto.version && manifiesto.description);
+});
+
+prueba("no pide webRequest (la ruta B no lo necesita)", function () {
+  assert.ok(
+    (manifiesto.permissions || []).indexOf("webRequest") === -1,
+    "webRequest sobra: la URL la da inject.js y las tramas no pasan por ahí"
+  );
+});
+
+prueba("los permisos son los mínimos: cookies y storage", function () {
+  assert.deepStrictEqual((manifiesto.permissions || []).slice().sort(), [
+    "cookies",
+    "storage",
+  ]);
+});
+
+prueba("sólo habla con tiktok.com y con 127.0.0.1:8790", function () {
+  const hosts = manifiesto.host_permissions || [];
+  assert.deepStrictEqual(hosts.slice().sort(), [
+    "http://127.0.0.1:8790/*",
+    "https://*.tiktok.com/*",
+  ]);
+  hosts.forEach(function (h) {
+    assert.ok(
+      /tiktok\.com/.test(h) || /127\.0\.0\.1/.test(h),
+      "host de tercero en el manifiesto: " + h
+    );
+  });
+});
+
+prueba("logica.js va antes que inject.js y que content.js en los dos mundos", function () {
+  const cs = manifiesto.content_scripts || [];
+  assert.strictEqual(cs.length, 2);
+  const mundos = cs.map(function (e) {
+    return e.world;
+  });
+  assert.ok(mundos.indexOf("MAIN") !== -1 && mundos.indexOf("ISOLATED") !== -1);
+  cs.forEach(function (e) {
+    assert.strictEqual(e.run_at, "document_start", "hay que estar antes que TikTok");
+    assert.strictEqual(e.js[0], "logica.js", "logica.js tiene que cargarse primero");
+  });
+});
+
+prueba("todos los archivos que nombra el manifiesto existen", function () {
+  const esperados = ["background.js", "popup.html", "popup.js", "logica.js", "inject.js", "content.js"];
+  esperados.forEach(function (f) {
+    assert.ok(fs.existsSync(path.join(RAIZ, f)), "falta " + f);
+  });
+  assert.strictEqual(manifiesto.background.service_worker, "background.js");
+  assert.strictEqual(manifiesto.action.default_popup, "popup.html");
+});
+
+prueba("ningún archivo de la extensión menciona sessionid como cookie a enviar", function () {
+  ["background.js", "content.js", "inject.js", "popup.js"].forEach(function (f) {
+    const texto = fs.readFileSync(path.join(RAIZ, f), "utf8");
+    const lineas = texto.split("\n").filter(function (l) {
+      return /sessionid/.test(l) && !/^\s*\/\//.test(l.trim());
+    });
+    assert.strictEqual(
+      lineas.length,
+      0,
+      f + " menciona sessionid fuera de un comentario: " + lineas.join(" | ")
+    );
+  });
+});
+
+prueba("ninguna URL de tercero: sólo 127.0.0.1", function () {
+  ["background.js", "content.js", "inject.js", "popup.js"].forEach(function (f) {
+    const texto = fs.readFileSync(path.join(RAIZ, f), "utf8");
+    const urls = texto.match(/https?:\/\/[^\s"'`)]+/g) || [];
+    urls.forEach(function (u) {
+      assert.ok(
+        u.indexOf("127.0.0.1") !== -1,
+        f + " apunta a un tercero: " + u
+      );
+    });
+  });
+});
+
+// =====================================================================
+grupo("8. Accesibilidad del popup (lo que NVDA necesita)");
+
+const HTML = fs.readFileSync(path.join(RAIZ, "popup.html"), "utf8");
+const JS_POPUP = fs.readFileSync(path.join(RAIZ, "popup.js"), "utf8");
+
+prueba("la página declara el idioma (NVDA elige la voz por esto)", function () {
+  assert.ok(/<html[^>]+lang="es"/.test(HTML), 'falta lang="es" en <html>');
+});
+
+prueba("tiene título y un único encabezado de nivel 1", function () {
+  assert.ok(/<title>[^<]+<\/title>/.test(HTML), "falta <title>");
+  const h1 = HTML.match(/<h1[\s>]/g) || [];
+  assert.strictEqual(h1.length, 1, "tiene que haber exactamente un h1");
+  assert.ok((HTML.match(/<h2[\s>]/g) || []).length >= 3, "faltan encabezados de sección");
+});
+
+prueba("todos los botones son <button> de verdad y tienen texto", function () {
+  const botones = HTML.match(/<button[^>]*>[\s\S]*?<\/button>/g) || [];
+  assert.ok(botones.length >= 3, "esperaba al menos 3 botones");
+  botones.forEach(function (b) {
+    const texto = b.replace(/<[^>]*>/g, "").trim();
+    assert.ok(texto.length > 0, "botón sin nombre accesible: " + b);
+    assert.ok(/type="button"/.test(b), "botón sin type explícito: " + texto);
+  });
+  // Nada de divs clicables haciendo de botón.
+  assert.ok(!/<div[^>]*onclick/i.test(HTML), "hay un div haciendo de botón");
+});
+
+prueba("el cuadro de diagnóstico tiene una <label> de verdad asociada", function () {
+  const idsControles = (HTML.match(/<(?:textarea|input|select)[^>]*id="([^"]+)"/g) || []).map(
+    function (t) {
+      return t.match(/id="([^"]+)"/)[1];
+    }
+  );
+  assert.ok(idsControles.length > 0, "no hay controles de formulario que comprobar");
+  idsControles.forEach(function (id) {
+    const etiqueta = new RegExp('<label[^>]*for="' + id + '"[^>]*>([\\s\\S]*?)</label>');
+    const m = HTML.match(etiqueta);
+    assert.ok(m, "el control " + id + " no tiene <label for>");
+    assert.ok(
+      m[1].replace(/<[^>]*>/g, "").trim().length > 0,
+      "la label de " + id + " está vacía"
+    );
+  });
+});
+
+prueba("hay una región viva educada para anunciar el estado", function () {
+  assert.ok(/role="status"/.test(HTML), 'falta el role="status" del resumen');
+  // Y NO puede refrescarse sola con un temporizador: hablaría sin parar.
+  assert.ok(
+    !/setInterval/.test(JS_POPUP),
+    "el popup no debe refrescarse en bucle: marearía al lector de pantalla"
+  );
+});
+
+prueba("todos los id que usa popup.js existen en popup.html", function () {
+  const usados = new Set();
+  const re = /\$\("([^"]+)"\)/g;
+  let m;
+  while ((m = re.exec(JS_POPUP)) !== null) usados.add(m[1]);
+  assert.ok(usados.size >= 5, "esperaba más ids en uso, ¿cambió la forma de $()?");
+  usados.forEach(function (id) {
+    assert.ok(
+      new RegExp('id="' + id + '"').test(HTML),
+      "popup.js usa el id '" + id + "' y popup.html no lo tiene"
+    );
+  });
+});
+
+prueba("no hay scripts en línea (los prohíbe la CSP de Manifest V3)", function () {
+  const enLinea = (HTML.match(/<script(?![^>]*\ssrc=)[^>]*>[\s\S]*?<\/script>/g) || []).filter(
+    function (s) {
+      return s.replace(/<[^>]*>/g, "").trim().length > 0;
+    }
+  );
+  assert.strictEqual(enLinea.length, 0, "hay script en línea: " + enLinea.join(""));
+  assert.ok(
+    HTML.indexOf('src="logica.js"') < HTML.indexOf('src="popup.js"'),
+    "logica.js tiene que cargarse antes que popup.js"
+  );
+});
+
+prueba("el estado se comunica con palabras, no sólo con color", function () {
+  // Si el resumen o el detalle dependieran de una clase de color, aquí
+  // aparecerían cosas como classList.add('rojo'). No hay nada de eso.
+  assert.ok(
+    !/classList\.(add|remove|toggle)\((['"])(rojo|verde|ok|error|malo|bueno)/.test(JS_POPUP),
+    "el estado no puede depender de un color"
+  );
+  ["escuchando", "enganchado", "Tramas enviadas"].forEach(function (palabra) {
+    assert.ok(JS_POPUP.indexOf(palabra) !== -1, "falta el estado escrito: " + palabra);
+  });
+});
+
+// =====================================================================
+console.log("\n=======================================");
+console.log("Pruebas pasadas: " + pasadas);
+console.log("Pruebas falladas: " + fallos.length);
+if (fallos.length > 0) {
+  console.log("\nFallos:");
+  fallos.forEach(function (f) {
+    console.log("  - " + f.nombre);
+    console.log("    " + (f.error && f.error.stack ? f.error.stack : f.error));
+  });
+  process.exit(1);
+}
+console.log("Todo en verde.");

--- a/recibir_captura.py
+++ b/recibir_captura.py
@@ -1,0 +1,194 @@
+"""Modo de prueba manual del firmador local: mirar qué manda la extensión.
+
+Levanta el mismo servidor local que usa VeTube (servicios/tiktok_interceptor) y
+va contando lo que llega. Sirve para cerrar la parte del navegador sin tener que
+abrir VeTube entera: si acá se ven tramas y parsean, la mitad Python funciona.
+
+Imprime SOLO la forma de lo que llega, nunca su contenido: cuántas tramas, de
+qué tipo, si parsean y qué clases de evento traen. Ni los mensajes del chat, ni
+los nombres de la gente, ni las cookies, ni la query firmada del websocket, que
+es justo lo que no debe salir de la máquina. Tampoco guarda nada en disco.
+
+Cómo ejecutarlo (desde la carpeta de VeTube, con su venv):
+
+    cd "C:\\Users\\phaza\\cosas github\\VeTube"
+    .venv\\Scripts\\python.exe recibir_captura.py
+
+Dejalo corriendo, abrí el directo en el navegador con la extensión puesta y
+escuchá lo que va imprimiendo. Ctrl+C para salir.
+
+La salida es texto lineal, una cosa por línea, sin tablas ni barras de progreso:
+está pensada para leerse con lector de pantalla.
+"""
+
+import os
+import sys
+import time
+from collections import Counter
+from urllib.parse import parse_qs, urlparse
+
+# Permite ejecutarlo aunque no estés justo en la carpeta de VeTube.
+RAIZ_VETUBE = os.path.dirname(os.path.abspath(__file__))
+if RAIZ_VETUBE not in sys.path:
+    sys.path.insert(0, RAIZ_VETUBE)
+
+from TikTokLive.client.ws.ws_utils import extract_webcast_push_frame  # noqa: E402
+
+from servicios.tiktok_espejo import decodificar_trama  # noqa: E402
+from servicios.tiktok_interceptor import (  # noqa: E402
+    VERSION_CONTRATO,
+    ServidorInterceptor,
+)
+
+PUERTO = 8790
+# Cada cuánto se resume lo acumulado. Un resumen por segundo sería ilegible con
+# lector de pantalla; cada diez da tiempo a escucharlo entero.
+CADA_S = 10
+
+
+class Cuenta:
+    """Lo que se sabe de una sesión sin mirar dentro de los mensajes."""
+
+    def __init__(self):
+        self.tramas = 0
+        self.con_eventos = 0
+        self.transporte = 0
+        self.ilegibles = 0
+        self.menor = None
+        self.mayor = None
+        self.tipos = Counter()
+        self.eventos = Counter()
+
+    def anotar(self, crudo):
+        self.tramas += 1
+        largo = len(crudo)
+        self.menor = largo if self.menor is None else min(self.menor, largo)
+        self.mayor = largo if self.mayor is None else max(self.mayor, largo)
+        try:
+            tipo = extract_webcast_push_frame(crudo).payload_type or "(sin tipo)"
+        except Exception:
+            tipo = "(no parsea)"
+        self.tipos[tipo] += 1
+
+        respuesta = decodificar_trama(crudo)
+        if respuesta is None:
+            # Sin eventos: o es transporte (hb, ack) o la trama vino rota.
+            if tipo == "msg":
+                self.ilegibles += 1
+            else:
+                self.transporte += 1
+            return
+        self.con_eventos += 1
+        for mensaje in respuesta.messages:
+            # El nombre de la clase de evento es del protocolo, no del usuario.
+            self.eventos[mensaje.method or "(sin nombre)"] += 1
+
+    def lineas(self):
+        yield (
+            f"  tramas: {self.tramas}, con eventos: {self.con_eventos}, "
+            f"de transporte: {self.transporte}, ilegibles: {self.ilegibles}."
+        )
+        if self.menor is not None:
+            yield f"  tamaños: de {self.menor} a {self.mayor} bytes."
+        if self.tipos:
+            yield "  tipos de trama: " + ", ".join(
+                f"{t} {n}" for t, n in sorted(self.tipos.items())
+            ) + "."
+        if self.eventos:
+            yield "  eventos vistos: " + ", ".join(
+                f"{e} {n}" for e, n in self.eventos.most_common(8)
+            ) + "."
+        else:
+            yield "  eventos vistos: ninguno todavía."
+
+
+def contar_captura(captura):
+    """La forma de una captura de la ruta A. Nunca su firma ni sus cookies."""
+    partes = urlparse(captura.ws_url)
+    parametros = sorted(parse_qs(partes.query))
+    print()
+    print("Captura de URL firmada recibida (ruta A):")
+    print(f"  usuario: @{captura.unique_id or '(sin nombre)'}, sala: {captura.room_id}.")
+    print(f"  host del websocket: {partes.hostname}.")
+    print(f"  ruta: {partes.path}.")
+    print(f"  ¿es el webcast?: {'webcast-ws.tiktok.com' in (partes.hostname or '')}.")
+    print(f"  parámetros de la query: {len(parametros)}.")
+    print("  nombres de los parámetros: " + (", ".join(parametros) or "ninguno") + ".")
+    print("  nombres de las cookies: " + (", ".join(sorted(captura.cookies)) or "ninguna") + ".")
+    print(f"  largo de la URL: {len(captura.ws_url)} caracteres (no se imprime).")
+
+
+def main():
+    # Puerto por argumento por si el 8790 ya lo tiene otra cosa (VeTube abierta,
+    # u otra copia de este mismo receptor): el arranque falla claro, no en silencio.
+    puerto = int(sys.argv[1]) if len(sys.argv) > 1 else PUERTO
+    try:
+        servidor = ServidorInterceptor(puerto=puerto)
+    except OSError as e:
+        print(f"No se pudo abrir el puerto {puerto}: {e}.")
+        print("¿Hay otra copia de VeTube o de este receptor abierta?")
+        print("Se puede probar en otro puerto, por ejemplo: recibir_captura.py 8791.")
+        return
+    servidor.iniciar()
+    print(f"Receptor listo en http://127.0.0.1:{puerto}, contrato versión {VERSION_CONTRATO}.")
+    print("Abrí el directo en el navegador con la extensión puesta.")
+    print(f"Se resume lo que llegue cada {CADA_S} segundos. Ctrl+C para salir.")
+
+    cuentas = {}
+    capturas_vistas = set()
+    estados_vistos = {}
+    arranque = time.time()
+    proximo_resumen = arranque + CADA_S
+
+    try:
+        while True:
+            for captura in list(servidor.almacen._por_usuario.values()):
+                if captura.ws_url in capturas_vistas:
+                    continue
+                capturas_vistas.add(captura.ws_url)
+                contar_captura(captura)
+
+            for sesion in list(servidor.sesiones._por_usuario.values()):
+                nombre = sesion.unique_id or "(sin nombre)"
+                if estados_vistos.get(nombre) != sesion.estado:
+                    estados_vistos[nombre] = sesion.estado
+                    print()
+                    print(
+                        f"El navegador dice que el directo de @{nombre} está "
+                        f"{sesion.estado}. Sala: {sesion.room_id or 'sin informar'}. "
+                        f"Host: {sesion.host_ws or 'sin informar'}."
+                    )
+                cuenta = cuentas.setdefault(nombre, Cuenta())
+                # Se vacía la cola porque acá no hay ninguna VeTube esperándola.
+                while True:
+                    crudo = sesion.cola.siguiente(0.05)
+                    if not isinstance(crudo, (bytes, bytearray)):
+                        break  # SIN_TRAMA o el centinela de cierre
+                    cuenta.anotar(bytes(crudo))
+
+            if time.time() >= proximo_resumen:
+                proximo_resumen = time.time() + CADA_S
+                segundos = int(time.time() - arranque)
+                if not cuentas:
+                    print()
+                    print(f"A los {segundos} segundos todavía no llegó nada.")
+                for nombre, cuenta in cuentas.items():
+                    sesion = servidor.sesiones.obtener(nombre)
+                    print()
+                    print(f"Resumen de @{nombre} a los {segundos} segundos:")
+                    for linea in cuenta.lineas():
+                        print(linea)
+                    if sesion is not None:
+                        print(
+                            f"  huecos de secuencia: {sesion.huecos}. "
+                            f"Descartadas por cola llena: {sesion.cola.descartadas}."
+                        )
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        print()
+        print("Cerrando el receptor.")
+        servidor.detener()
+
+
+if __name__ == "__main__":
+    main()

--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -190,9 +190,24 @@ class ServicioTiktok:
         if self.is_running and self.loop and self.loop.is_running():
             self.is_running = False
             logger.info("Deteniendo servicio de TikTok...")
-            if self.chat:
-                asyncio.run_coroutine_threadsafe(self.chat.disconnect(), self.loop)
-            self.loop.call_soon_threadsafe(self.loop.stop)
+            # Cerrar y frenar en una sola corutina: así el disconnect se espera
+            # (await) de verdad antes de parar el bucle. Antes se programaba el
+            # disconnect por un lado y el stop por otro; si el bucle paraba
+            # primero, la corutina del disconnect quedaba sin await y saltaba un
+            # RuntimeWarning ("coroutine was never awaited").
+            loop = self.loop
+            chat = self.chat
+
+            async def _cerrar_y_frenar():
+                try:
+                    if chat:
+                        await chat.disconnect()
+                except Exception:
+                    logger.debug("Cierre del cliente con incidencia menor", exc_info=True)
+                finally:
+                    loop.stop()
+
+            asyncio.run_coroutine_threadsafe(_cerrar_y_frenar(), loop)
 
     def _instalar_firmador_local(self):
         """Deja el cliente leyendo el chat del navegador, si la opción está marcada.

--- a/servicios/tiktok.py
+++ b/servicios/tiktok.py
@@ -75,6 +75,11 @@ class ServicioTiktok:
         self.media_controller = None
         self.translator = None
         self.filtrar_anteriores = False
+        # Fallback al navegador: si la conexion normal (firmador remoto) falla,
+        # se ofrece leer del navegador una sola vez. _usando_navegador es True
+        # desde el arranque solo si ya se eligio el navegador en el desplegable.
+        self._usando_navegador = False
+        self._navegador_ofrecido = False
 
     def iniciar_chat(self):
         self.is_running = True
@@ -118,6 +123,7 @@ class ServicioTiktok:
                 raise ValueError(_("No se pudo obtener la URL real de TikTok."))
             self.chat = TikTokLiveClient(unique_id=user_id)
             self._instrumentar_historial()
+            self._instalar_firmador_local()
             self._add_listeners()
             await self._run_client_async()
         except Exception as e:
@@ -158,10 +164,25 @@ class ServicioTiktok:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                if self.is_running:
-                    logger.exception("Error en el bucle del cliente")
-                    wx.CallAfter(self.chat_controller.notificar_error, str(e))
-                    self.detener()
+                if not self.is_running:
+                    break
+                # El firmador remoto de TikTok suele caerse. Si la conexion
+                # normal falla y todavia no probamos el navegador, ofrecerlo una
+                # sola vez: si acepta, se instala el espejo y se reintenta en el
+                # mismo bucle; si no, se informa el error como siempre.
+                if not self._usando_navegador and not self._navegador_ofrecido:
+                    self._navegador_ofrecido = True
+                    logger.info(
+                        "La conexion normal de TikTok fallo; se ofrece el navegador: %s",
+                        e,
+                    )
+                    acepta = await asyncio.to_thread(self._ofrecer_navegador)
+                    if acepta and self.is_running and self._activar_navegador():
+                        self.last_live_status = None
+                        continue
+                logger.exception("Error en el bucle del cliente")
+                wx.CallAfter(self.chat_controller.notificar_error, str(e))
+                self.detener()
 
     def detener(self):
         if self.media_controller:
@@ -172,6 +193,106 @@ class ServicioTiktok:
             if self.chat:
                 asyncio.run_coroutine_threadsafe(self.chat.disconnect(), self.loop)
             self.loop.call_soon_threadsafe(self.loop.stop)
+
+    def _instalar_firmador_local(self):
+        """Deja el cliente leyendo el chat del navegador, si la opción está marcada.
+
+        TikTok exige que la petición al websocket del chat vaya firmada, y el
+        servicio externo que la firmaba está caído. El navegador del usuario, en
+        cambio, ya tiene el directo abierto con su websocket firmado y andando: la
+        extensión copia esas tramas y las manda a un puerto local. Aquí solo se
+        cambia de dónde saca el cliente sus mensajes (ver servicios/tiktok_espejo).
+
+        Apagado de fábrica: sin la extensión puesta no llegaría nada y el chat se
+        quedaría esperando en silencio, que es peor que fallar.
+        """
+        if not data_store.config.get("tiktok_firmador_local", False):
+            return
+        try:
+            from servicios import tiktok_espejo, tiktok_interceptor
+
+            servidor = tiktok_interceptor.servidor_compartido()
+            tiktok_espejo.instalar_espejo(
+                self.chat, servidor.sesiones, avisar=self._avisar_firmador
+            )
+            self._usando_navegador = True
+            self._navegador_ofrecido = True  # ya esta en el navegador: no ofrecerlo
+        except OSError:
+            # El puerto ocupado casi siempre significa otra copia de VeTube abierta;
+            # decirlo es más útil que un traceback en el log.
+            logger.exception("No se pudo abrir el puerto del firmador local")
+            wx.CallAfter(
+                self.chat_controller.notificar_error,
+                _(
+                    "No se pudo abrir el puerto del firmador local. "
+                    "¿Hay otra copia de VeTube abierta?"
+                ),
+            )
+        except Exception:
+            # Que falle el firmador no debe tumbar el chat: sin él, el cliente sigue
+            # intentando la conexión normal y el error queda en el log.
+            logger.exception("No se pudo instalar el firmador local")
+
+    def _avisar_firmador(self, texto):
+        # El espejo corre en el hilo de asyncio; los avisos tienen que volver al
+        # hilo de wx para que el lector de pantalla los anuncie.
+        wx.CallAfter(reader.leer_aviso, _(texto))
+
+    def _ofrecer_navegador(self):
+        """Muestra el cartel y espera la respuesta. Corre fuera del bucle asyncio
+        (con asyncio.to_thread) para no congelarlo mientras el dialogo esta abierto."""
+        import threading
+
+        evento = threading.Event()
+        resultado = {"aceptado": False}
+
+        def mostrar():
+            try:
+                dlg = wx.MessageDialog(
+                    self.frame,
+                    _(
+                        "No se pudo conectar al chat de TikTok por el servicio "
+                        "habitual (suele estar caido).\n\n"
+                        "Se puede leer desde el navegador. Asegurate de tener la "
+                        "extension de VeTube instalada y este directo abierto en "
+                        "el navegador, y pulsa Aceptar cuando este listo."
+                    ),
+                    _("Leer TikTok desde el navegador"),
+                    wx.OK | wx.CANCEL | wx.ICON_INFORMATION,
+                )
+                resultado["aceptado"] = dlg.ShowModal() == wx.ID_OK
+                dlg.Destroy()
+            finally:
+                evento.set()
+
+        wx.CallAfter(mostrar)
+        evento.wait()
+        return resultado["aceptado"]
+
+    def _activar_navegador(self):
+        """Instala el espejo sobre el cliente ya creado para reintentar leyendo
+        del navegador. Devuelve True si quedo listo."""
+        try:
+            from servicios import tiktok_espejo, tiktok_interceptor
+
+            servidor = tiktok_interceptor.servidor_compartido()
+            tiktok_espejo.instalar_espejo(
+                self.chat, servidor.sesiones, avisar=self._avisar_firmador
+            )
+            self._usando_navegador = True
+            return True
+        except OSError:
+            logger.exception("No se pudo abrir el puerto del firmador local")
+            wx.CallAfter(
+                self.chat_controller.notificar_error,
+                _(
+                    "No se pudo abrir el puerto del firmador local. "
+                    "¿Hay otra copia de VeTube abierta?"
+                ),
+            )
+        except Exception:
+            logger.exception("No se pudo instalar el firmador local")
+        return False
 
     def _instrumentar_historial(self):
         # TikTokLiveClient recibe de TikTok un indicador fiable (is_history) que dice si un

--- a/servicios/tiktok_espejo.py
+++ b/servicios/tiktok_espejo.py
@@ -1,0 +1,333 @@
+"""Ruta B del firmador local: VeTube no abre ningún websocket, mira el del navegador.
+
+El navegador del usuario, al abrir el directo, ya tiene su websocket firmado y
+funcionando. La extensión copia las tramas binarias tal cual llegan y las manda a
+servicios/tiktok_interceptor por el puerto local; aquí se traducen a los objetos
+que TikTokLive espera y se meten en su flujo de eventos, sin volver a firmar
+nada y sin que la sesión del usuario salga de su navegador.
+
+Los acks y los latidos los sigue mandando el navegador por ese mismo socket, así
+que VeTube no debe mandar ninguno: el espejo es de solo lectura. Esa es la
+diferencia de fondo con la ruta A, donde VeTube abría su propio socket con una
+URL firmada que caduca a los 30 segundos y que además el navegador ya consumió.
+
+--------------------------------------------------------------------------------
+Dónde enchufa (verificado sobre TikTokLive 7.0.1 instalada)
+--------------------------------------------------------------------------------
+`TikTokLiveClient` le pide al cliente de websocket exactamente tres cosas, y
+nada más, en client.py:
+
+    línea 171  if self._ws.connected:              -> AlreadyConnectedError
+    línea 358  await self._ws.disconnect()
+    línea 475  async for webcast_response in self._ws.connect(...)
+    línea 810  return self._ws.connected           (la propiedad pública)
+
+Con esa superficie tan chica sale más limpio sustituir el objeto entero
+(`client._ws = WebsocketEspejo(...)`) que parchear métodos sueltos de
+WebcastWSClient y arrastrar su estado sin usar: el contador de seq, el bucle de
+ping y el generador de conexión existen solo para hablar por un socket que aquí
+no hay. Un espejo que no los tiene no puede mandar un latido por descuido.
+
+La otra sustitución es la del firmador: `client.web.fetch_signed_websocket`, la
+única llamada al servidor de firmas (client.py línea 207), que aquí se limita a
+esperar a que el navegador aparezca y devolver un estado inicial vacío.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from logging import getLogger
+from typing import Callable, Optional
+
+from TikTokLive.client.ws.ws_utils import (
+    extract_webcast_push_frame,
+    extract_webcast_response_message,
+)
+from TikTokLive.proto import ProtoMessageFetchResult
+
+from servicios.tiktok_interceptor import (
+    CENTINELA_CIERRE,
+    ESPERA_CAPTURA_S,
+    SIN_TRAMA,
+    AlmacenSesiones,
+    SesionNavegador,
+    normalizar_id,
+)
+
+logger = getLogger(__name__)
+
+
+def decodificar_trama(datos: bytes) -> Optional[ProtoMessageFetchResult]:
+    """Una trama binaria del navegador, convertida en lo que espera la librería.
+
+    Devuelve None cuando la trama no trae eventos, que es lo normal en buena
+    parte de ellas: solo las de payload_type "msg" llevan mensajes. Las de tipo
+    "hb" (el latido que manda el servidor), "ack" e "im_enter_room_resp" son
+    transporte, y la propia librería las tira igual (ws_connect.py, dentro de
+    __aiter__). También devuelve None si la trama no parsea: una trama rota no
+    vale un corte de conexión en mitad de un directo.
+
+    El desempaquetado (gzip o sin comprimir, según la cabecera compress_type) lo
+    hace extract_webcast_response_message, o sea la propia librería. Aquí no se
+    reimplementa nada del protocolo.
+    """
+    try:
+        trama = extract_webcast_push_frame(datos, logger=logger)
+    except Exception:
+        logger.debug(
+            "Trama descartada: no parsea como WebcastPushFrame (%s bytes)",
+            len(datos or b""),
+        )
+        return None
+
+    if trama.payload_type != "msg":
+        logger.debug(
+            "Trama de transporte ignorada (tipo=%r, %s bytes de carga)",
+            trama.payload_type,
+            len(trama.payload or b""),
+        )
+        return None
+
+    try:
+        respuesta = extract_webcast_response_message(trama, logger=logger)
+    except Exception:
+        logger.warning(
+            "Trama 'msg' de %s bytes que no se pudo desempaquetar; se sigue",
+            len(trama.payload or b""),
+        )
+        return None
+
+    # is_first solo lo trae el estado inicial. Si una trama del navegador llegara
+    # marcada, la librería emitiría otro ConnectEvent y VeTube volvería a decir
+    # "Ingresando al chat" por el lector de pantalla en mitad del chat.
+    respuesta.is_first = False
+    return respuesta
+
+
+class WebsocketEspejo:
+    """Ocupa el sitio del cliente de websocket sin abrir ninguno.
+
+    Cumple la superficie que usa TikTokLiveClient (connected / disconnect /
+    connect) leyendo de la cola que llena el servidor local. No manda nada: ni
+    acks, ni latidos, ni el mensaje de entrada a la sala. De eso se sigue
+    encargando el navegador, que es quien tiene el socket de verdad.
+    """
+
+    # Cada cuánto despierta la espera de tramas. Solo marca lo que tarda en
+    # notarse un cierre; las tramas que llegan despiertan la cola al instante.
+    ESPERA_TRAMA_S = 1.0
+
+    def __init__(
+        self,
+        sesiones: AlmacenSesiones,
+        unique_id: str,
+        *,
+        timeout: float = ESPERA_CAPTURA_S,
+        avisar: Optional[Callable[[str], None]] = None,
+    ):
+        self._sesiones = sesiones
+        self._unique_id = normalizar_id(unique_id)
+        self._timeout = timeout
+        self._avisar = avisar
+        self.sesion: Optional[SesionNavegador] = None
+        self._abierto = False
+        self._cierre_pedido = False
+        self.tramas_vistas = 0
+        self.tramas_con_eventos = 0
+
+    # -- la superficie que usa TikTokLiveClient -----------------------------
+
+    @property
+    def connected(self) -> bool:
+        return self._abierto
+
+    async def disconnect(self) -> None:
+        self._cierre_pedido = True
+        self._abierto = False
+        if self.sesion is not None:
+            # Cerrar la cola despierta la espera en el acto: sin esto, detener
+            # el chat tardaría lo que queda de ESPERA_TRAMA_S en notarse.
+            self.sesion.cola.cerrar()
+
+    async def connect(
+        self,
+        room_id=None,
+        cookies=None,
+        user_agent=None,
+        initial_webcast_response: Optional[ProtoMessageFetchResult] = None,
+        process_connect_events: bool = True,
+        compress_ws_events: bool = True,
+    ):
+        """Generador de ProtoMessageFetchResult, alimentado por el navegador.
+
+        Misma firma y mismo contrato que WebcastWSClient.connect: el bucle de
+        client.py (_ws_client_loop) no distingue. cookies, user_agent y
+        compress_ws_events se aceptan y se ignoran a propósito: el socket es del
+        navegador y ya negoció todo eso por su cuenta.
+        """
+        sesion = self.sesion
+        if sesion is None:
+            sesion = await asyncio.to_thread(
+                self._sesiones.esperar, self._unique_id, self._timeout
+            )
+        if sesion is None:
+            raise TimeoutError(
+                "El navegador no abrió ningún directo. ¿Está la extensión "
+                "puesta y el directo abierto en una pestaña?"
+            )
+        self.sesion = sesion
+        self._abierto = not self._cierre_pedido
+
+        logger.info(
+            "Espejo enganchado al navegador para @%s (sala %s)",
+            sesion.unique_id or "(comodín)",
+            sesion.room_id or "desconocida",
+        )
+        self._aviso("Leyendo el chat desde el navegador.")
+
+        try:
+            if initial_webcast_response is not None:
+                # Igual que la librería: con la casilla de historial desmarcada,
+                # el estado inicial se entrega sin sus mensajes.
+                if not process_connect_events:
+                    initial_webcast_response.messages = []
+                yield initial_webcast_response
+
+            while self._abierto:
+                crudo = await asyncio.to_thread(
+                    sesion.cola.siguiente, self.ESPERA_TRAMA_S
+                )
+                if crudo is CENTINELA_CIERRE:
+                    break
+                if crudo is SIN_TRAMA:
+                    # Silencio en el chat, no desconexión: se sigue esperando
+                    # mientras el navegador tenga el directo abierto.
+                    if not sesion.abierta:
+                        break
+                    continue
+
+                self.tramas_vistas += 1
+                respuesta = decodificar_trama(crudo)
+                if respuesta is None:
+                    continue
+                self.tramas_con_eventos += 1
+                yield respuesta
+        finally:
+            self._abierto = False
+            logger.info(
+                "Espejo desenganchado de @%s: %s tramas vistas, %s con eventos",
+                sesion.unique_id or "(comodín)",
+                self.tramas_vistas,
+                self.tramas_con_eventos,
+            )
+
+    # -- interno -------------------------------------------------------------
+
+    def _aviso(self, texto: str) -> None:
+        """Un aviso para el usuario, si quien instaló el espejo pasó por dónde.
+
+        Se hace por callback y no importando wx aquí para que este módulo siga
+        siendo importable (y testeable) sin interfaz gráfica.
+        """
+        if self._avisar is None:
+            return
+        try:
+            self._avisar(texto)
+        except Exception:
+            logger.debug("Fallo al avisar al usuario", exc_info=True)
+
+
+def instalar_espejo(
+    client,
+    sesiones: AlmacenSesiones,
+    *,
+    timeout: float = ESPERA_CAPTURA_S,
+    avisar: Optional[Callable[[str], None]] = None,
+) -> WebsocketEspejo:
+    """Deja el cliente de TikTokLive leyendo del navegador en vez de la red.
+
+    Sustituye cuatro cosas, todas por el mismo motivo: que nada del arranque
+    dependa de TikTok cuando el navegador ya tiene la respuesta.
+
+      1. client._ws                       -> el espejo (no abre websocket)
+      2. client.web.fetch_signed_websocket -> espera al navegador, sin firmar
+      3. client.web.fetch_room_id_from_html -> la sala que informó la extensión
+      4. client.web.fetch_is_live           -> hay sesión abierta, luego hay directo
+
+    Las dos últimas conservan la implementación original como respaldo, para no
+    empeorar el caso en que el navegador todavía no avisó de nada.
+
+    Es el mismo patrón de sustitución que servicios/tiktok.py ya usa en
+    _instrumentar_historial.
+    """
+    id_cliente = normalizar_id(getattr(client, "unique_id", ""))
+    espejo = WebsocketEspejo(sesiones, id_cliente, timeout=timeout, avisar=avisar)
+
+    async def fetch_desde_navegador(platform=None, *args, **kwargs):
+        """El estado inicial que la librería pide al firmador, sin firmador.
+
+        No lleva push_server ni route_params porque nadie va a construir una
+        URL con ellos: el espejo no conecta. is_first sí, que es lo que hace
+        que TikTokLive emita el ConnectEvent con el que VeTube anuncia la
+        entrada al chat.
+        """
+        logger.info(
+            "Esperando a que el navegador abra el directo de @%s (hasta %ss)...",
+            id_cliente,
+            int(timeout),
+        )
+        if avisar is not None:
+            avisar(
+                "Abrí el directo en el navegador con la extensión puesta. Esperando..."
+            )
+        # El almacén bloquea con hilos; se saca del hilo del bucle asyncio.
+        sesion = await asyncio.to_thread(sesiones.esperar, id_cliente, timeout)
+        if sesion is None:
+            raise TimeoutError(
+                "No llegó ninguna sesión del navegador. ¿Está el directo "
+                "abierto en el navegador con la extensión puesta?"
+            )
+        espejo.sesion = sesion
+        return ProtoMessageFetchResult(
+            messages=[],
+            cursor="0",
+            route_params={},
+            push_server="",
+            history_comment_cursor="0",
+            is_first=True,
+        )
+
+    room_id_original = client.web.fetch_room_id_from_html
+    is_live_original = client.web.fetch_is_live
+
+    # Los nombres de los parámetros son los de la librería a propósito: la
+    # llama con palabra clave (fetch_is_live(unique_id=...)) y renombrarlos
+    # mandaría el valor a **kwargs sin que nadie lo notara.
+    async def room_id_del_navegador(unique_id=None, *args, **kwargs):
+        """La sala que informó la extensión, que es la que el usuario está viendo.
+
+        Evita el raspado del HTML del directo, que es justo lo que TikTok
+        responde con captcha cuando le da por ahí.
+        """
+        sesion = sesiones.obtener(unique_id or id_cliente)
+        if sesion is not None and sesion.room_id:
+            return str(sesion.room_id)
+        logger.debug("La extensión no informó la sala; se raspa el HTML como antes")
+        return await room_id_original(unique_id or id_cliente, *args, **kwargs)
+
+    async def esta_en_vivo(room_id=None, unique_id=None, *args, **kwargs):
+        """Si el navegador tiene el directo abierto, está en vivo: no hay más que mirar."""
+        sesion = sesiones.obtener(unique_id or id_cliente)
+        if sesion is not None and sesion.abierta:
+            return True
+        return await is_live_original(
+            room_id=room_id, unique_id=unique_id or id_cliente
+        )
+
+    client._ws = espejo
+    client.web.fetch_signed_websocket = fetch_desde_navegador
+    client.web.fetch_room_id_from_html = room_id_del_navegador
+    client.web.fetch_is_live = esta_en_vivo
+
+    logger.info("Firmador local (ruta espejo) instalado para @%s", id_cliente)
+    return espejo

--- a/servicios/tiktok_interceptor.py
+++ b/servicios/tiktok_interceptor.py
@@ -1,0 +1,689 @@
+"""Firmador local: la mitad de VeTube. Recibe lo que ve el navegador del usuario.
+
+ESTADO: detrás de la opción «tiktok_firmador_local», apagada de fábrica.
+
+--------------------------------------------------------------------------------
+La idea
+--------------------------------------------------------------------------------
+TikTok no deja abrir el websocket del chat sin una petición firmada. Hasta ahora
+esa firma la calculaba un servidor externo (EulerStream), que se cae y comparte
+cupo. En vez de eso, el navegador del usuario —logueado o no— que abre el directo
+YA hace esa petición firmada él solo. Una extensión mira lo que el navegador hace
+y se lo pasa a VeTube por este puerto local. La firma nunca se recalcula y la
+sesión del usuario no sale de su navegador.
+
+Este módulo es la mitad que vive dentro de VeTube: el servidor local que recibe.
+La otra mitad (traducir lo recibido a eventos de TikTokLive) está en
+servicios/tiktok_espejo.py.
+
+--------------------------------------------------------------------------------
+Las dos rutas
+--------------------------------------------------------------------------------
+Ruta A (`/captura`, `instalar()`): se copia la URL firmada del websocket y VeTube
+abre su propio websocket con ella. Es frágil por dos motivos documentados en la
+propia librería: las URLs firmadas caducan a los 30 segundos (ws_connect.py, en
+el comentario de __aiter__) y encima el navegador ya la consumió. Se conserva
+porque cuesta poco y sirve de plan de emergencia.
+
+Ruta B (`/sesion` + `/tramas`, ver tiktok_espejo): el navegador se queda con su
+websocket y la extensión copia las tramas binarias tal cual llegan. VeTube no
+abre ningún websocket a TikTok: parsea esas tramas y las mete en el flujo de
+eventos de la librería. Los acks y los latidos los sigue mandando el navegador,
+así que VeTube no debe mandarlos. Es la ruta principal.
+
+--------------------------------------------------------------------------------
+Contrato con la extensión (versión 2)
+--------------------------------------------------------------------------------
+    GET  /salud    -> 200 {"ok": true, "version": 2}
+    POST /captura  -> ruta A. {"unique_id","room_id","ws_url","cookies":{...},"cursor"}
+    POST /sesion   -> aviso de estado. {"unique_id","room_id","estado":"abierto"|"cerrado","ws_url"}
+    POST /tramas   -> ruta B. {"unique_id","room_id","seq":<entero>,
+                               "tramas":["<base64 de la trama binaria>", ...]}
+                      respuesta {"ok": true, "recibidas": <n>}
+
+`seq` es monotónico por sesión y solo sirve para detectar huecos: si llega uno no
+consecutivo se anota en el log y se sigue, porque perder tramas de un chat en
+vivo no es motivo para tirar la conexión.
+
+Nada de esto contacta con TikTok: eso lo hace el navegador del usuario. Este
+módulo solo escucha en 127.0.0.1.
+
+--------------------------------------------------------------------------------
+Qué NO se registra
+--------------------------------------------------------------------------------
+Ni valores de cookies, ni sessionid, ni la query firmada. Del websocket solo se
+guarda la forma: host, cantidades, longitudes. Es la regla que hace que este
+puente sea aceptable en primer lugar.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import threading
+import time
+from collections import deque
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from logging import getLogger
+from typing import Optional
+from urllib.parse import urlparse
+
+import httpx
+from TikTokLive.proto import ProtoMessageFetchResult
+
+logger = getLogger(__name__)
+
+PUERTO_POR_DEFECTO = 8790
+# Versión del contrato con la extensión. Si esto sube, la extensión tiene que
+# enterarse: /salud lo publica para que pueda avisar en vez de fallar en silencio.
+VERSION_CONTRATO = 2
+# Cuánto espera el firmador a que el navegador aparezca antes de rendirse. El
+# usuario tiene que abrir el directo con la extensión puesta; darle margen es
+# razonable, más aún moviéndose con lector de pantalla.
+ESPERA_CAPTURA_S = 120
+# Tope de tramas en espera por sesión. Acotado a propósito: si la extensión
+# manda y VeTube todavía no consume, de un chat en vivo lo que interesa es lo
+# último, no lo primero.
+MAX_TRAMAS_EN_COLA = 2000
+
+# Centinelas de ColaTramas.siguiente(): objetos que se comparan por identidad,
+# porque una trama vacía (b"") es un valor posible y no debe confundirse.
+CENTINELA_CIERRE = object()
+SIN_TRAMA = object()
+
+
+def normalizar_id(valor) -> str:
+    """@Usuario, Usuario y usuario son el mismo directo."""
+    return str(valor or "").lstrip("@").strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# Ruta A: la URL firmada
+# ---------------------------------------------------------------------------
+
+
+class Captura:
+    """Una conexión firmada tal y como la observó el navegador."""
+
+    def __init__(self, datos: dict):
+        self.unique_id = normalizar_id(datos.get("unique_id"))
+        self.room_id = str(datos.get("room_id", "")) or None
+        self.ws_url = str(datos.get("ws_url", ""))
+        self.cursor = str(datos.get("cursor", "") or "0")
+        self.recibida_en = time.time()
+        # Cookies: se aceptan como diccionario o como cabecera "a=1; b=2".
+        self.cookies: dict[str, str] = {}
+        if isinstance(datos.get("cookies"), dict):
+            self.cookies = {str(k): str(v) for k, v in datos["cookies"].items()}
+        elif datos.get("cookie_header"):
+            for trozo in str(datos["cookie_header"]).split(";"):
+                if "=" in trozo:
+                    k, _, v = trozo.partition("=")
+                    self.cookies[k.strip()] = v.strip()
+
+    def es_valida(self) -> bool:
+        return self.ws_url.startswith("wss://") and "tiktok" in self.ws_url
+
+    def coincide_con(self, unique_id: str) -> bool:
+        # Sin unique_id en la captura, se acepta como comodín: el interceptor
+        # más simple puede no saber el nombre y mandar solo la URL.
+        if not self.unique_id:
+            return True
+        return self.unique_id == normalizar_id(unique_id)
+
+
+class AlmacenCapturas:
+    """Guarda la última captura de cada directo, con espera bloqueante."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._por_usuario: dict[str, Captura] = {}
+        self._evento = threading.Event()
+
+    def guardar(self, captura: Captura) -> None:
+        with self._lock:
+            self._por_usuario[captura.unique_id] = captura
+        self._evento.set()
+        logger.info(
+            "Captura del interceptor recibida (usuario=%r, room=%s)",
+            captura.unique_id or "(comodín)",
+            captura.room_id,
+        )
+
+    def esperar(self, unique_id: str, timeout: float) -> Optional[Captura]:
+        """Bloquea hasta que haya una captura para ese usuario, o None si vence."""
+        limite = time.time() + timeout
+        while time.time() < limite:
+            with self._lock:
+                for cap in self._por_usuario.values():
+                    # Un unique_id de consulta vacío es comodín: acepta cualquier
+                    # captura válida. (coincide_con maneja el comodín del lado de
+                    # la captura; aquí faltaba el del lado de la consulta.)
+                    if cap.es_valida() and (
+                        not unique_id or cap.coincide_con(unique_id)
+                    ):
+                        return cap
+            self._evento.wait(timeout=1.0)
+            self._evento.clear()
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Ruta B: las tramas del websocket del navegador
+# ---------------------------------------------------------------------------
+
+
+class ColaTramas:
+    """Cola acotada que cruza del hilo del servidor HTTP al del bucle asyncio.
+
+    No se usa queue.Queue porque interesa descartar por la izquierda: cuando se
+    llena, lo que sobra son las tramas viejas, no las que acaban de llegar. Un
+    chat en vivo leído en voz alta con retraso es peor que un chat con huecos.
+    """
+
+    def __init__(self, maximo: int = MAX_TRAMAS_EN_COLA):
+        self._cond = threading.Condition()
+        self._tramas: deque = deque(maxlen=maximo)
+        self._cerrada = False
+        self.descartadas = 0
+
+    def publicar(self, datos: bytes) -> None:
+        with self._cond:
+            if self._cerrada:
+                return
+            if len(self._tramas) == self._tramas.maxlen:
+                self.descartadas += 1
+            self._tramas.append(datos)
+            self._cond.notify()
+
+    def cerrar(self) -> None:
+        with self._cond:
+            self._cerrada = True
+            self._cond.notify_all()
+
+    @property
+    def cerrada(self) -> bool:
+        with self._cond:
+            return self._cerrada
+
+    def pendientes(self) -> int:
+        with self._cond:
+            return len(self._tramas)
+
+    def siguiente(self, timeout: float):
+        """La próxima trama, SIN_TRAMA si venció la espera, CENTINELA_CIERRE al final.
+
+        Las tramas ya encoladas se entregan aunque la cola esté cerrada: cerrar
+        significa «el navegador se fue», no «tirá lo que quedaba».
+        """
+        with self._cond:
+            if not self._tramas and not self._cerrada:
+                self._cond.wait(timeout)
+            if self._tramas:
+                return self._tramas.popleft()
+            if self._cerrada:
+                return CENTINELA_CIERRE
+            return SIN_TRAMA
+
+
+class SesionNavegador:
+    """Lo que el navegador tiene abierto ahora mismo para un directo.
+
+    El websocket del webcast se reutiliza entre salas (la ruta real termina en
+    /ws_reuse_supplement/), así que cambiar de directo NO abre un socket nuevo:
+    por eso room_id puede cambiar sin que la sesión se cierre.
+    """
+
+    def __init__(self, unique_id: str, room_id: Optional[str] = None):
+        self.unique_id = normalizar_id(unique_id)
+        self.room_id = str(room_id) if room_id else None
+        self.estado = "abierto"
+        self.abierta_en = time.time()
+        self.tramas_recibidas = 0
+        self.huecos = 0
+        self.host_ws: Optional[str] = None
+        self._seq_esperado: Optional[int] = None
+        self.cola = ColaTramas()
+
+    def anotar_seq(self, seq: Optional[int]) -> bool:
+        """Registra el número de secuencia. False si hubo hueco (no es un error)."""
+        if seq is None:
+            return True
+        continuo = self._seq_esperado is None or seq == self._seq_esperado
+        if not continuo:
+            self.huecos += 1
+            logger.warning(
+                "Hueco en la secuencia de tramas de @%s: esperaba %s y llegó %s "
+                "(se sigue igual, %s huecos en esta sesión)",
+                self.unique_id or "(comodín)",
+                self._seq_esperado,
+                seq,
+                self.huecos,
+            )
+        self._seq_esperado = seq + 1
+        return continuo
+
+    def publicar(self, tramas) -> None:
+        for trama in tramas:
+            self.cola.publicar(trama)
+        self.tramas_recibidas += len(tramas)
+
+    def cerrar(self) -> None:
+        self.estado = "cerrado"
+        self.cola.cerrar()
+
+    def reabrir(self, room_id: Optional[str] = None) -> None:
+        """Cola nueva al reabrir: la anterior ya entregó su centinela de cierre."""
+        if self.estado == "cerrado":
+            self.cola = ColaTramas()
+            self._seq_esperado = None
+        self.estado = "abierto"
+        self.abierta_en = time.time()
+        if room_id:
+            self.room_id = str(room_id)
+
+    @property
+    def abierta(self) -> bool:
+        return self.estado == "abierto"
+
+
+class AlmacenSesiones:
+    """Las sesiones de navegador vivas, por usuario, con espera bloqueante."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._por_usuario: dict[str, SesionNavegador] = {}
+        self._evento = threading.Event()
+
+    def _obtener_o_crear(self, unique_id: str, room_id=None) -> SesionNavegador:
+        clave = normalizar_id(unique_id)
+        sesion = self._por_usuario.get(clave)
+        if sesion is None:
+            sesion = SesionNavegador(clave, room_id)
+            self._por_usuario[clave] = sesion
+        elif room_id:
+            sesion.room_id = str(room_id)
+        return sesion
+
+    def abrir(self, unique_id: str, room_id=None, host_ws=None) -> SesionNavegador:
+        with self._lock:
+            sesion = self._obtener_o_crear(unique_id, room_id)
+            sesion.reabrir(room_id)
+            if host_ws:
+                sesion.host_ws = host_ws
+        self._evento.set()
+        logger.info(
+            "El navegador abrió el directo de @%s (sala %s, host %s)",
+            sesion.unique_id or "(comodín)",
+            sesion.room_id or "desconocida",
+            sesion.host_ws or "sin informar",
+        )
+        return sesion
+
+    def cerrar(self, unique_id: str) -> Optional[SesionNavegador]:
+        with self._lock:
+            sesion = self._por_usuario.get(normalizar_id(unique_id))
+        if sesion is None:
+            return None
+        sesion.cerrar()
+        logger.info(
+            "El navegador cerró el directo de @%s tras %s tramas",
+            sesion.unique_id or "(comodín)",
+            sesion.tramas_recibidas,
+        )
+        return sesion
+
+    def agregar_tramas(
+        self, unique_id: str, room_id, seq: Optional[int], tramas
+    ) -> SesionNavegador:
+        """Encola tramas. Abre la sesión sola si la extensión no avisó por /sesion."""
+        with self._lock:
+            sesion = self._obtener_o_crear(unique_id, room_id)
+            if not sesion.abierta:
+                sesion.reabrir(room_id)
+        sesion.anotar_seq(seq)
+        sesion.publicar(tramas)
+        self._evento.set()
+        return sesion
+
+    def obtener(self, unique_id: str) -> Optional[SesionNavegador]:
+        """La sesión de ese usuario; con unique_id vacío, cualquiera abierta."""
+        clave = normalizar_id(unique_id)
+        with self._lock:
+            if clave:
+                sesion = self._por_usuario.get(clave)
+                if sesion is not None:
+                    return sesion
+                # Comodín del lado de la extensión: puede no saber el nombre del
+                # dueño del directo y mandar las tramas sin él.
+                return self._por_usuario.get("")
+            for sesion in self._por_usuario.values():
+                if sesion.abierta:
+                    return sesion
+            return None
+
+    def esperar(self, unique_id: str, timeout: float) -> Optional[SesionNavegador]:
+        """Bloquea hasta que haya una sesión abierta para ese usuario."""
+        limite = time.time() + timeout
+        while True:
+            sesion = self.obtener(unique_id)
+            if sesion is not None and sesion.abierta:
+                return sesion
+            if time.time() >= limite:
+                return None
+            self._evento.wait(timeout=1.0)
+            self._evento.clear()
+
+    def resumen(self):
+        """Forma, no secretos: lo que puede enseñarse en una consola o en la UI."""
+        with self._lock:
+            sesiones = list(self._por_usuario.values())
+        return [
+            {
+                "unique_id": s.unique_id or "(comodín)",
+                "room_id": s.room_id,
+                "estado": s.estado,
+                "tramas": s.tramas_recibidas,
+                "huecos": s.huecos,
+                "en_cola": s.cola.pendientes(),
+                "descartadas": s.cola.descartadas,
+            }
+            for s in sesiones
+        ]
+
+
+# ---------------------------------------------------------------------------
+# El servidor
+# ---------------------------------------------------------------------------
+
+
+class _ErrorPeticion(Exception):
+    """Payload que no cumple el contrato. Se responde 400 con el motivo."""
+
+
+def _decodificar_tramas(valor):
+    """Las tramas base64 del payload, ya en binario. Lanza si algo no cuadra."""
+    if not isinstance(valor, list):
+        raise _ErrorPeticion("'tramas' tiene que ser una lista")
+    tramas = []
+    for i, elemento in enumerate(valor):
+        if not isinstance(elemento, str):
+            raise _ErrorPeticion(f"la trama {i} no es una cadena base64")
+        try:
+            # validate=True para que un alfabeto raro falle en vez de colarse
+            # como bytes truncados en silencio.
+            tramas.append(base64.b64decode(elemento, validate=True))
+        except (binascii.Error, ValueError) as e:
+            raise _ErrorPeticion(f"la trama {i} no es base64 válido: {e}") from e
+    return tramas
+
+
+def _leer_seq(valor) -> Optional[int]:
+    """El número de secuencia, tolerando que venga como texto."""
+    if valor is None:
+        return None
+    if isinstance(valor, bool):  # bool es int en Python, y aquí no significa nada
+        raise _ErrorPeticion("'seq' tiene que ser un entero")
+    if isinstance(valor, int):
+        return valor
+    if isinstance(valor, str) and valor.strip().isdigit():
+        return int(valor.strip())
+    raise _ErrorPeticion("'seq' tiene que ser un entero")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    almacen: AlmacenCapturas = None  # se asignan al crear el servidor
+    sesiones: AlmacenSesiones = None
+
+    # El navegador manda desde el service worker de la extensión (una página de
+    # tiktok.com no puede llamar a 127.0.0.1: Chrome la corta antes de emitirla).
+    # Aun así se responde con CORS permisivo y con la cabecera de red privada,
+    # que es la que Chrome exige para dejar salir una petición hacia loopback.
+    def _cabeceras_cors(self) -> None:
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Access-Control-Allow-Private-Network", "true")
+
+    def _responder(self, codigo: int, cuerpo: dict) -> None:
+        datos = json.dumps(cuerpo).encode("utf-8")
+        self.send_response(codigo)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(datos)))
+        self._cabeceras_cors()
+        self.end_headers()
+        self.wfile.write(datos)
+
+    def _cuerpo_json(self) -> dict:
+        largo = int(self.headers.get("Content-Length", 0) or 0)
+        try:
+            datos = json.loads(self.rfile.read(largo) or b"{}")
+        except json.JSONDecodeError as e:
+            raise _ErrorPeticion(f"el cuerpo no es JSON válido: {e}") from e
+        if not isinstance(datos, dict):
+            raise _ErrorPeticion("el cuerpo tiene que ser un objeto JSON")
+        return datos
+
+    def do_OPTIONS(self):  # noqa: N802 (lo exige la clase base)
+        self.send_response(204)
+        self.send_header("Access-Control-Max-Age", "86400")
+        self._cabeceras_cors()
+        self.end_headers()
+
+    def do_GET(self):  # noqa: N802
+        ruta = self.path.split("?", 1)[0].rstrip("/")
+        if ruta == "/salud":
+            self._responder(200, {"ok": True, "version": VERSION_CONTRATO})
+        elif ruta == "/estado":
+            # Fuera del contrato con la extensión: es para mirar desde una
+            # consola qué está llegando. Solo forma, nunca valores.
+            self._responder(200, {"ok": True, "sesiones": self.sesiones.resumen()})
+        else:
+            self._responder(404, {"error": "ruta desconocida"})
+
+    def do_POST(self):  # noqa: N802
+        ruta = self.path.split("?", 1)[0].rstrip("/")
+        rutas = {
+            "/captura": self._post_captura,
+            "/sesion": self._post_sesion,
+            "/tramas": self._post_tramas,
+        }
+        manejador = rutas.get(ruta)
+        if manejador is None:
+            self._responder(404, {"error": "ruta desconocida"})
+            return
+        try:
+            manejador(self._cuerpo_json())
+        except _ErrorPeticion as e:
+            self._responder(400, {"error": str(e)})
+        except Exception as e:
+            logger.exception("Error procesando %s del interceptor", ruta)
+            self._responder(400, {"error": str(e)})
+
+    def _post_captura(self, datos: dict) -> None:
+        captura = Captura(datos)
+        if not captura.es_valida():
+            raise _ErrorPeticion("ws_url ausente o no es de TikTok")
+        self.almacen.guardar(captura)
+        self._responder(200, {"ok": True})
+
+    def _post_sesion(self, datos: dict) -> None:
+        estado = str(datos.get("estado", "")).strip().lower()
+        if estado not in ("abierto", "cerrado"):
+            raise _ErrorPeticion("'estado' tiene que ser 'abierto' o 'cerrado'")
+        unique_id = datos.get("unique_id", "")
+        if estado == "abierto":
+            # De la ws_url solo se mira el host, para poder distinguir el
+            # webcast de la mensajería privada (im-ws-sg.tiktok.com), que es
+            # otro websocket y no interesa.
+            host = None
+            if datos.get("ws_url"):
+                host = urlparse(str(datos["ws_url"])).hostname
+            self.sesiones.abrir(unique_id, datos.get("room_id"), host_ws=host)
+        else:
+            self.sesiones.cerrar(unique_id)
+        self._responder(200, {"ok": True})
+
+    def _post_tramas(self, datos: dict) -> None:
+        if "tramas" not in datos:
+            raise _ErrorPeticion("falta 'tramas'")
+        tramas = _decodificar_tramas(datos["tramas"])
+        seq = _leer_seq(datos.get("seq"))
+        self.sesiones.agregar_tramas(
+            datos.get("unique_id", ""), datos.get("room_id"), seq, tramas
+        )
+        self._responder(200, {"ok": True, "recibidas": len(tramas)})
+
+    def log_message(self, *args):
+        # Silencia el log a stderr del servidor base; ya usamos logging.
+        pass
+
+
+class ServidorInterceptor:
+    """Servidor local al que el interceptor manda lo que ve. Solo 127.0.0.1."""
+
+    def __init__(self, puerto: int = PUERTO_POR_DEFECTO):
+        self.almacen = AlmacenCapturas()
+        self.sesiones = AlmacenSesiones()
+        handler = type(
+            "Handler",
+            (_Handler,),
+            {"almacen": self.almacen, "sesiones": self.sesiones},
+        )
+
+        # allow_reuse_address desactivado a propósito: en Windows, con el reuso
+        # activo (el valor por defecto de http.server) varios procesos pueden
+        # quedar pegados al mismo puerto a la vez y el SO reparte las peticiones
+        # entre ellos de forma impredecible. Sin reuso, un segundo arranque
+        # falla claro ("puerto en uso") en vez de crear un listener fantasma.
+        class _Servidor(ThreadingHTTPServer):
+            allow_reuse_address = False
+            daemon_threads = True
+
+        self._httpd = _Servidor(("127.0.0.1", puerto), handler)
+        self.puerto = self._httpd.server_address[1]
+        self._hilo: Optional[threading.Thread] = None
+
+    def iniciar(self) -> None:
+        if self._hilo and self._hilo.is_alive():
+            return
+        self._hilo = threading.Thread(
+            target=self._httpd.serve_forever, name="tiktok-interceptor", daemon=True
+        )
+        self._hilo.start()
+        logger.info("Interceptor escuchando en http://127.0.0.1:%s", self.puerto)
+
+    def detener(self) -> None:
+        try:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+        except Exception:
+            logger.debug("Cierre del interceptor con incidencia menor", exc_info=True)
+
+
+# Un único servidor por proceso: el puerto es uno solo y el usuario puede
+# conectar y desconectar varios chats seguidos sin que haga falta reabrirlo.
+_servidor_compartido: Optional[ServidorInterceptor] = None
+_lock_compartido = threading.Lock()
+
+
+def servidor_compartido(puerto: int = PUERTO_POR_DEFECTO) -> ServidorInterceptor:
+    """El servidor del proceso, arrancándolo la primera vez que se pide."""
+    global _servidor_compartido
+    with _lock_compartido:
+        if _servidor_compartido is None:
+            _servidor_compartido = ServidorInterceptor(puerto=puerto)
+            _servidor_compartido.iniciar()
+        return _servidor_compartido
+
+
+def detener_servidor_compartido() -> None:
+    """Para el servidor del proceso, si lo hay (al cerrar la app o en tests)."""
+    global _servidor_compartido
+    with _lock_compartido:
+        if _servidor_compartido is not None:
+            _servidor_compartido.detener()
+            _servidor_compartido = None
+
+
+# ---------------------------------------------------------------------------
+# Ruta A: inyectar la URL firmada en la librería
+# ---------------------------------------------------------------------------
+
+
+def _fetch_result_desde_captura(captura: Captura) -> ProtoMessageFetchResult:
+    """Construye el objeto que espera TikTokLive para el estado inicial.
+
+    push_server/route_params quedan de relleno: la URL de verdad se inyecta como
+    `uri` (ver instalar), y el generador de conexión la usa verbatim. Lo que sí
+    importa aquí es el cursor y una lista de mensajes vacía para arrancar.
+    """
+    return ProtoMessageFetchResult(
+        messages=[],
+        cursor=captura.cursor,
+        route_params={},
+        push_server=captura.ws_url,
+        history_comment_cursor="0",
+    )
+
+
+def instalar(client, almacen: AlmacenCapturas, *, timeout: float = ESPERA_CAPTURA_S):
+    """Ruta A: sustituye el firmador del cliente por la URL que vio el navegador.
+
+    Deja `client.web.fetch_signed_websocket` de forma que, en vez de llamar a
+    EulerStream, espere la captura del navegador y la use. Es el mismo patrón de
+    sustitución que servicios/tiktok.py ya emplea con _parse_webcast_response_message.
+
+    Frágil por diseño: la URL firmada caduca a los 30 segundos y el navegador ya
+    la consumió (ver el comentario de __aiter__ en ws_connect.py de la librería).
+    La ruta buena es la B, en servicios/tiktok_espejo.py.
+    """
+    unique_id = normalizar_id(getattr(client, "unique_id", ""))
+
+    async def fetch_interceptado(
+        platform=None, *args, **kwargs
+    ) -> ProtoMessageFetchResult:
+        import asyncio
+
+        logger.info(
+            "Esperando una captura del interceptor para @%s (hasta %ss)...",
+            unique_id,
+            int(timeout),
+        )
+        # El almacén bloquea con hilos; se saca del hilo del bucle asyncio para
+        # no congelarlo.
+        captura = await asyncio.to_thread(almacen.esperar, unique_id, timeout)
+        if captura is None:
+            raise TimeoutError(
+                "No llegó ninguna captura del interceptor. ¿Está el directo "
+                "abierto en el navegador con la extensión puesta?"
+            )
+
+        # 1) cookies capturadas -> cookies del cliente web (el websocket las lee de ahí)
+        for nombre, valor in captura.cookies.items():
+            try:
+                client.web.cookies.set(nombre, valor, ".tiktok.com")
+            except Exception:
+                logger.debug("No se pudo fijar la cookie %r", nombre, exc_info=True)
+
+        # 2) URL capturada -> uri verbatim del websocket (salta build_webcast_uri)
+        try:
+            client._ws._ws_kwargs["uri"] = captura.ws_url
+        except Exception:
+            logger.exception("No se pudo inyectar el uri capturado en el websocket")
+
+        # 3) estado inicial para la librería
+        return _fetch_result_desde_captura(captura)
+
+    client.web.fetch_signed_websocket = fetch_interceptado
+    logger.info("Firmador reemplazado por el interceptor local para @%s", unique_id)
+
+
+def esta_escuchando(puerto: int = PUERTO_POR_DEFECTO) -> bool:
+    """True si hay un ServidorInterceptor vivo en ese puerto (útil para la UI)."""
+    try:
+        r = httpx.get(f"http://127.0.0.1:{puerto}/salud", timeout=2)
+        return r.status_code == 200 and r.json().get("ok") is True
+    except Exception:
+        return False

--- a/tests/test_tiktok_espejo.py
+++ b/tests/test_tiktok_espejo.py
@@ -1,0 +1,291 @@
+"""Pruebas de la ruta B: las tramas del navegador convertidas en eventos.
+
+Las tramas se fabrican con el protobuf de la propia librería, así que ninguna
+prueba habla con TikTok ni guarda capturas reales (que llevan firma dentro).
+Los generadores se recorren con asyncio.run para no depender de la configuración
+de pytest-asyncio.
+"""
+
+import asyncio
+import inspect
+import re
+
+from TikTokLive.client.ws.ws_client import WebcastWSClient
+from TikTokLive.proto import ProtoMessageFetchResult
+
+from servicios.tiktok_espejo import WebsocketEspejo, decodificar_trama, instalar_espejo
+from servicios.tiktok_interceptor import AlmacenSesiones
+from tests.tramas_sinteticas import trama, trama_hb, trama_msg
+
+# --- decodificar una trama ----------------------------------------------------
+
+
+def test_trama_msg_sin_comprimir():
+    resultado = decodificar_trama(trama_msg("WebcastChatMessage", compress_type="none"))
+
+    assert [m.method for m in resultado.messages] == ["WebcastChatMessage"]
+    assert resultado.need_ack is True
+
+
+def test_trama_msg_en_gzip():
+    # En un directo real llegan las dos: compress_type 'none' y 'gzip'.
+    resultado = decodificar_trama(
+        trama_msg("WebcastMemberMessage", "WebcastLikeMessage", compress_type="gzip")
+    )
+
+    assert [m.method for m in resultado.messages] == [
+        "WebcastMemberMessage",
+        "WebcastLikeMessage",
+    ]
+
+
+def test_trama_msg_sin_cabecera_de_compresion():
+    resultado = decodificar_trama(trama_msg("WebcastChatMessage", compress_type=None))
+
+    assert len(resultado.messages) == 1
+
+
+def test_trama_msg_sin_mensajes_no_es_un_error():
+    # Las primeras tramas de una sala llegan así; tirarlas como si fueran basura
+    # sería confundir "no hay nada que leer" con "algo se rompió".
+    resultado = decodificar_trama(trama_msg())
+
+    assert isinstance(resultado, ProtoMessageFetchResult)
+    assert resultado.messages == []
+
+
+def test_trama_de_latido_se_ignora():
+    assert decodificar_trama(trama_hb()) is None
+
+
+def test_trama_de_ack_se_ignora():
+    assert decodificar_trama(trama(b"", payload_type="ack")) is None
+
+
+def test_trama_vacia_se_ignora():
+    assert decodificar_trama(b"") is None
+
+
+def test_trama_rota_no_revienta():
+    # Una trama rota no vale un corte de conexión en mitad de un directo.
+    assert decodificar_trama(b"\xff" * 40) is None
+
+
+def test_las_tramas_del_navegador_no_vuelven_a_anunciar_la_entrada():
+    # is_first solo lo trae el estado inicial: si se colara en una trama, VeTube
+    # volvería a decir "Ingresando al chat" por el lector de pantalla.
+    marcada = bytes(ProtoMessageFetchResult(cursor="1", is_first=True))
+
+    resultado = decodificar_trama(trama(marcada))
+
+    assert resultado.is_first is False
+
+
+# --- el espejo ----------------------------------------------------------------
+
+
+def _estado_inicial():
+    return ProtoMessageFetchResult(messages=[], cursor="0", is_first=True)
+
+
+def _recorrer(espejo, inicial):
+    """Consume el generador entero. Termina cuando la sesión ya está cerrada."""
+
+    async def corrida():
+        return [
+            r
+            async for r in espejo.connect(
+                room_id=7563, initial_webcast_response=inicial
+            )
+        ]
+
+    return asyncio.run(corrida())
+
+
+def test_el_espejo_entrega_el_estado_inicial_y_luego_lo_del_navegador():
+    sesiones = AlmacenSesiones()
+    sesion = sesiones.abrir("pia", room_id="7563")
+    sesiones.agregar_tramas(
+        "pia",
+        "7563",
+        1,
+        [trama_msg("WebcastChatMessage"), trama_hb(), trama_msg("WebcastGiftMessage")],
+    )
+    sesiones.cerrar("pia")  # el centinela hace terminar el generador
+    espejo = WebsocketEspejo(sesiones, "pia")
+    espejo.sesion = sesion
+    inicial = _estado_inicial()
+
+    salidas = _recorrer(espejo, inicial)
+
+    assert salidas[0] is inicial
+    # El latido queda por el camino: no trae eventos.
+    assert [m.method for r in salidas[1:] for m in r.messages] == [
+        "WebcastChatMessage",
+        "WebcastGiftMessage",
+    ]
+    assert espejo.tramas_vistas == 3
+    assert espejo.tramas_con_eventos == 2
+    assert espejo.connected is False
+
+
+def test_el_espejo_respeta_la_casilla_de_mensajes_anteriores():
+    sesiones = AlmacenSesiones()
+    sesion = sesiones.abrir("pia")
+    sesiones.cerrar("pia")
+    espejo = WebsocketEspejo(sesiones, "pia")
+    espejo.sesion = sesion
+    inicial = ProtoMessageFetchResult(cursor="0", is_first=True)
+    inicial.messages = list(decodificar_trama(trama_msg("WebcastChatMessage")).messages)
+
+    async def corrida():
+        return [
+            r
+            async for r in espejo.connect(
+                initial_webcast_response=inicial, process_connect_events=False
+            )
+        ]
+
+    salidas = asyncio.run(corrida())
+
+    assert salidas[0].messages == []
+
+
+def test_el_espejo_termina_cuando_el_navegador_cierra():
+    sesiones = AlmacenSesiones()
+    sesion = sesiones.abrir("pia")
+    espejo = WebsocketEspejo(sesiones, "pia")
+    espejo.sesion = sesion
+
+    async def corrida():
+        salidas = []
+        async for respuesta in espejo.connect(initial_webcast_response=_estado_inicial()):
+            salidas.append(respuesta)
+            # El usuario cierra la pestaña del directo justo después de entrar.
+            sesiones.cerrar("pia")
+        return salidas
+
+    assert len(asyncio.run(corrida())) == 1
+
+
+def test_detener_el_chat_corta_el_espejo_en_el_acto():
+    sesiones = AlmacenSesiones()
+    sesion = sesiones.abrir("pia")
+    espejo = WebsocketEspejo(sesiones, "pia")
+    espejo.sesion = sesion
+
+    async def corrida():
+        await espejo.disconnect()
+        return [
+            r async for r in espejo.connect(initial_webcast_response=_estado_inicial())
+        ]
+
+    # Solo el estado inicial: no se queda esperando tramas que ya nadie quiere.
+    assert len(asyncio.run(corrida())) == 1
+    assert espejo.connected is False
+
+
+def test_el_espejo_se_rinde_si_el_navegador_nunca_aparece():
+    espejo = WebsocketEspejo(AlmacenSesiones(), "pia", timeout=0.2)
+
+    async def corrida():
+        async for _ in espejo.connect(initial_webcast_response=_estado_inicial()):
+            pass
+
+    try:
+        asyncio.run(corrida())
+    except TimeoutError as e:
+        assert "navegador" in str(e)
+    else:
+        raise AssertionError("tenía que rendirse")
+
+
+def test_el_espejo_no_puede_mandar_nada():
+    # El navegador es quien manda acks y latidos por su propio socket. Si el
+    # espejo tuviera con qué mandar, algún día alguien lo usaría.
+    for prohibido in ("send", "send_ack", "switch_rooms", "restart_ping_loop"):
+        assert not hasattr(WebsocketEspejo, prohibido)
+
+
+def test_el_espejo_cubre_todo_lo_que_la_libreria_le_pide():
+    """Canario: si TikTokLive empieza a pedirle algo más a client._ws, se nota acá."""
+    fuente = inspect.getsource(
+        __import__("TikTokLive.client.client", fromlist=["client"])
+    )
+    usados = set(re.findall(r"self\._ws\.(\w+)", fuente))
+
+    assert usados  # si esto falla, cambió el nombre del atributo en la librería
+    assert usados <= set(dir(WebsocketEspejo)), usados - set(dir(WebsocketEspejo))
+    # Y lo que se cubre es lo mismo que ofrece el cliente de verdad.
+    assert usados <= set(dir(WebcastWSClient))
+
+
+# --- instalar el espejo en un cliente -----------------------------------------
+
+
+class _WebFalso:
+    def __init__(self):
+        self.llamadas = []
+
+    async def fetch_signed_websocket(self, platform=None):
+        self.llamadas.append("firma")
+        raise AssertionError("el firmador externo no debería llamarse nunca")
+
+    async def fetch_room_id_from_html(self, unique_id=None):
+        self.llamadas.append("raspado")
+        return "999"
+
+    async def fetch_is_live(self, room_id=None, unique_id=None):
+        self.llamadas.append("is_live")
+        return False
+
+
+class _ClienteFalso:
+    def __init__(self):
+        self.unique_id = "@Pia"
+        self._ws = object()
+        self.web = _WebFalso()
+
+
+def test_instalar_el_espejo_cambia_los_cuatro_puntos():
+    cliente = _ClienteFalso()
+    sesiones = AlmacenSesiones()
+    sesiones.abrir("pia", room_id="7563")
+
+    espejo = instalar_espejo(cliente, sesiones, timeout=1)
+
+    assert cliente._ws is espejo
+    assert cliente.web.fetch_signed_websocket.__name__ == "fetch_desde_navegador"
+    assert asyncio.run(cliente.web.fetch_room_id_from_html("pia")) == "7563"
+    assert asyncio.run(cliente.web.fetch_is_live(unique_id="pia")) is True
+    # Nada de eso pasó por la red.
+    assert cliente.web.llamadas == []
+
+
+def test_sin_sesion_del_navegador_se_vuelve_a_lo_de_antes():
+    cliente = _ClienteFalso()
+
+    instalar_espejo(cliente, AlmacenSesiones(), timeout=1)
+
+    assert asyncio.run(cliente.web.fetch_room_id_from_html("pia")) == "999"
+    assert asyncio.run(cliente.web.fetch_is_live(unique_id="pia")) is False
+    assert cliente.web.llamadas == ["raspado", "is_live"]
+
+
+def test_el_estado_inicial_del_espejo_anuncia_la_entrada_al_chat():
+    cliente = _ClienteFalso()
+    sesiones = AlmacenSesiones()
+    sesion = sesiones.abrir("pia", room_id="7563")
+    avisos = []
+
+    espejo = instalar_espejo(cliente, sesiones, timeout=1, avisar=avisos.append)
+    inicial = asyncio.run(cliente.web.fetch_signed_websocket())
+
+    # is_first es lo que hace que TikTokLive emita el ConnectEvent con el que
+    # VeTube dice "Ingresando al chat".
+    assert inicial.is_first is True
+    assert inicial.messages == []
+    # Y no lleva URL ninguna: el espejo no conecta a nada.
+    assert inicial.push_server == ""
+    assert espejo.sesion is sesion
+    assert avisos  # al usuario se le avisa que hay que abrir el directo

--- a/tests/test_tiktok_interceptor.py
+++ b/tests/test_tiktok_interceptor.py
@@ -1,0 +1,346 @@
+"""Pruebas del servidor local del firmador: la mitad que recibe lo del navegador.
+
+Ninguna toca la red de TikTok. Las tramas se fabrican con el protobuf de la
+propia librería (ver tests/tramas_sinteticas.py) y el servidor se levanta en
+127.0.0.1 con puerto 0, o sea el que el sistema tenga libre, para que las
+pruebas no choquen con una VeTube abierta en el 8790.
+"""
+
+import logging
+
+import httpx
+import pytest
+
+from servicios.tiktok_interceptor import (
+    CENTINELA_CIERRE,
+    SIN_TRAMA,
+    VERSION_CONTRATO,
+    AlmacenSesiones,
+    Captura,
+    ColaTramas,
+    ServidorInterceptor,
+    SesionNavegador,
+)
+from tests.tramas_sinteticas import en_base64, trama_hb, trama_msg
+
+
+@pytest.fixture
+def servidor():
+    srv = ServidorInterceptor(puerto=0)
+    srv.iniciar()
+    yield srv
+    srv.detener()
+
+
+@pytest.fixture
+def url(servidor):
+    return f"http://127.0.0.1:{servidor.puerto}"
+
+
+# --- el contrato con la extensión -------------------------------------------
+
+
+def test_salud_publica_la_version_del_contrato(url):
+    r = httpx.get(url + "/salud", timeout=5)
+
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "version": VERSION_CONTRATO}
+
+
+def test_solo_escucha_en_loopback(servidor):
+    assert servidor._httpd.server_address[0] == "127.0.0.1"
+
+
+def test_options_responde_con_cors_y_red_privada(url):
+    r = httpx.request("OPTIONS", url + "/tramas", timeout=5)
+
+    assert r.status_code == 204
+    assert r.headers["Access-Control-Allow-Origin"] == "*"
+    assert "POST" in r.headers["Access-Control-Allow-Methods"]
+    # Chrome exige esta cabecera para dejar salir una petición hacia loopback.
+    assert r.headers["Access-Control-Allow-Private-Network"] == "true"
+
+
+def test_ruta_desconocida_da_404(url):
+    assert httpx.get(url + "/loquesea", timeout=5).status_code == 404
+    assert httpx.post(url + "/loquesea", json={}, timeout=5).status_code == 404
+
+
+# --- /tramas: la ruta B ------------------------------------------------------
+
+
+def test_las_tramas_llegan_enteras_a_la_cola(url, servidor):
+    unas = [trama_msg("WebcastChatMessage"), trama_hb()]
+
+    r = httpx.post(
+        url + "/tramas",
+        json={
+            "unique_id": "pia",
+            "room_id": "7563",
+            "seq": 1,
+            "tramas": [en_base64(t) for t in unas],
+        },
+        timeout=5,
+    )
+
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "recibidas": 2}
+    sesion = servidor.sesiones.obtener("pia")
+    assert sesion.room_id == "7563"
+    assert sesion.tramas_recibidas == 2
+    # El servidor no interpreta nada: los bytes salen tal y como entraron.
+    assert sesion.cola.siguiente(0.1) == unas[0]
+    assert sesion.cola.siguiente(0.1) == unas[1]
+
+
+def test_el_arroba_y_las_mayusculas_no_hacen_otra_sesion(url, servidor):
+    httpx.post(
+        url + "/tramas",
+        json={"unique_id": "@PiaPena", "seq": 1, "tramas": [en_base64(trama_hb())]},
+        timeout=5,
+    )
+
+    assert servidor.sesiones.obtener("piapena") is not None
+
+
+def test_tramas_sin_la_lista_se_rechazan(url):
+    r = httpx.post(url + "/tramas", json={"unique_id": "pia", "seq": 1}, timeout=5)
+
+    assert r.status_code == 400
+    assert "tramas" in r.json()["error"]
+
+
+def test_tramas_que_no_son_lista_se_rechazan(url):
+    r = httpx.post(url + "/tramas", json={"tramas": "unatrama"}, timeout=5)
+
+    assert r.status_code == 400
+
+
+def test_trama_que_no_es_base64_se_rechaza(url, servidor):
+    r = httpx.post(url + "/tramas", json={"tramas": ["no es base64!!"]}, timeout=5)
+
+    assert r.status_code == 400
+    assert "base64" in r.json()["error"]
+    # Y no se encoló nada a medias.
+    assert servidor.sesiones.obtener("") is None
+
+
+def test_trama_que_no_es_texto_se_rechaza(url):
+    r = httpx.post(url + "/tramas", json={"tramas": [1234]}, timeout=5)
+
+    assert r.status_code == 400
+
+
+def test_seq_que_no_es_entero_se_rechaza(url):
+    r = httpx.post(url + "/tramas", json={"seq": "ayer", "tramas": []}, timeout=5)
+
+    assert r.status_code == 400
+    assert "seq" in r.json()["error"]
+
+
+def test_cuerpo_que_no_es_json_se_rechaza(url):
+    r = httpx.post(
+        url + "/tramas",
+        content=b"{esto no es json",
+        headers={"Content-Type": "application/json"},
+        timeout=5,
+    )
+
+    assert r.status_code == 400
+
+
+def test_un_hueco_de_seq_no_corta_la_conexion(url, servidor):
+    httpx.post(url + "/tramas", json={"unique_id": "pia", "seq": 1, "tramas": []}, timeout=5)
+
+    r = httpx.post(
+        url + "/tramas",
+        json={"unique_id": "pia", "seq": 9, "tramas": [en_base64(trama_hb())]},
+        timeout=5,
+    )
+
+    assert r.status_code == 200
+    assert servidor.sesiones.obtener("pia").huecos == 1
+
+
+def test_el_hueco_de_seq_queda_anotado_en_el_log(caplog):
+    sesion = SesionNavegador("pia")
+    sesion.anotar_seq(1)
+
+    with caplog.at_level(logging.WARNING, logger="servicios.tiktok_interceptor"):
+        continuo = sesion.anotar_seq(7)
+
+    assert continuo is False
+    assert "Hueco en la secuencia" in caplog.text
+    # Tras el hueco se sigue contando desde donde llegó, no desde donde se esperaba.
+    assert sesion.anotar_seq(8) is True
+
+
+# --- /sesion -----------------------------------------------------------------
+
+
+def test_abrir_y_cerrar_la_sesion(url, servidor):
+    abrir = httpx.post(
+        url + "/sesion",
+        json={
+            "unique_id": "pia",
+            "room_id": "7563",
+            "estado": "abierto",
+            "ws_url": "wss://webcast-ws.tiktok.com/webcast/im/ws_proxy/"
+            "ws_reuse_supplement/?room_id=7563",
+        },
+        timeout=5,
+    )
+    assert abrir.status_code == 200
+    sesion = servidor.sesiones.obtener("pia")
+    assert sesion.abierta
+    # De la ws_url solo se guarda el host: la query lleva la firma.
+    assert sesion.host_ws == "webcast-ws.tiktok.com"
+
+    cerrar = httpx.post(
+        url + "/sesion", json={"unique_id": "pia", "estado": "cerrado"}, timeout=5
+    )
+
+    assert cerrar.status_code == 200
+    assert not sesion.abierta
+    assert sesion.cola.cerrada
+
+
+def test_estado_de_sesion_invalido_se_rechaza(url):
+    r = httpx.post(url + "/sesion", json={"unique_id": "pia", "estado": "quizas"}, timeout=5)
+
+    assert r.status_code == 400
+
+
+def test_reabrir_una_sesion_cerrada_da_una_cola_nueva():
+    sesiones = AlmacenSesiones()
+    sesion = sesiones.abrir("pia", room_id="1")
+    cola_vieja = sesion.cola
+    sesiones.cerrar("pia")
+
+    sesiones.abrir("pia", room_id="2")
+
+    assert sesion.cola is not cola_vieja
+    assert not sesion.cola.cerrada
+    assert sesion.room_id == "2"
+
+
+def test_esperar_devuelve_la_sesion_abierta_sin_nombre():
+    sesiones = AlmacenSesiones()
+    sesiones.abrir("pia")
+
+    # unique_id vacío en la consulta es comodín: sirve cualquier sesión abierta.
+    assert sesiones.esperar("", timeout=0.1) is not None
+
+
+def test_esperar_se_rinde_si_el_navegador_no_aparece():
+    assert AlmacenSesiones().esperar("pia", timeout=0.2) is None
+
+
+# --- la cola que cruza de hilo -----------------------------------------------
+
+
+def test_la_cola_avisa_cuando_no_llego_nada():
+    assert ColaTramas().siguiente(0.05) is SIN_TRAMA
+
+
+def test_la_cola_entrega_lo_pendiente_antes_del_centinela():
+    cola = ColaTramas()
+    cola.publicar(b"una")
+    cola.cerrar()
+
+    # Cerrar significa "el navegador se fue", no "tirá lo que quedaba".
+    assert cola.siguiente(0.05) == b"una"
+    assert cola.siguiente(0.05) is CENTINELA_CIERRE
+
+
+def test_la_cola_llena_descarta_las_viejas():
+    cola = ColaTramas(maximo=2)
+
+    for i in range(4):
+        cola.publicar(bytes([i]))
+
+    # De un chat en vivo interesa lo último: se pierden la 0 y la 1.
+    assert cola.siguiente(0.05) == b"\x02"
+    assert cola.siguiente(0.05) == b"\x03"
+    assert cola.descartadas == 2
+
+
+# --- /captura: la ruta A ------------------------------------------------------
+
+WS_FIRMADA = "wss://webcast-ws.tiktok.com/webcast/im/ws/?room_id=1&X-Bogus=x"
+
+
+def test_captura_con_cookies_como_diccionario(url, servidor):
+    r = httpx.post(
+        url + "/captura",
+        json={
+            "unique_id": "@Pia",
+            "room_id": "7563",
+            "ws_url": WS_FIRMADA,
+            "cookies": {"ttwid": "valor", "tt-target-idc": "otro"},
+        },
+        timeout=5,
+    )
+
+    assert r.status_code == 200
+    captura = servidor.almacen.esperar("pia", timeout=1)
+    assert sorted(captura.cookies) == ["tt-target-idc", "ttwid"]
+    assert captura.room_id == "7563"
+
+
+def test_captura_con_cookies_como_cabecera():
+    captura = Captura(
+        {
+            "unique_id": "pia",
+            "ws_url": WS_FIRMADA,
+            "cookie_header": "ttwid=valor; tt-target-idc=otro ; roto",
+        }
+    )
+
+    assert captura.cookies == {"ttwid": "valor", "tt-target-idc": "otro"}
+
+
+def test_captura_sin_ws_url_se_rechaza(url):
+    r = httpx.post(url + "/captura", json={"unique_id": "pia"}, timeout=5)
+
+    assert r.status_code == 400
+
+
+def test_captura_de_otro_sitio_se_rechaza(url):
+    r = httpx.post(
+        url + "/captura",
+        json={"unique_id": "pia", "ws_url": "wss://ejemplo.com/ws"},
+        timeout=5,
+    )
+
+    assert r.status_code == 400
+
+
+# --- /estado: el modo de prueba manual ---------------------------------------
+
+
+def test_estado_ensena_la_forma_y_ningun_secreto(url, servidor):
+    httpx.post(
+        url + "/sesion",
+        json={"unique_id": "pia", "room_id": "7563", "estado": "abierto"},
+        timeout=5,
+    )
+    httpx.post(
+        url + "/tramas",
+        json={"unique_id": "pia", "seq": 1, "tramas": [en_base64(trama_hb())]},
+        timeout=5,
+    )
+
+    cuerpo = httpx.get(url + "/estado", timeout=5).json()
+
+    assert cuerpo["sesiones"] == [
+        {
+            "unique_id": "pia",
+            "room_id": "7563",
+            "estado": "abierto",
+            "tramas": 1,
+            "huecos": 0,
+            "en_cola": 1,
+            "descartadas": 0,
+        }
+    ]

--- a/tests/tramas_sinteticas.py
+++ b/tests/tramas_sinteticas.py
@@ -1,0 +1,75 @@
+"""Utilidades compartidas por las pruebas del firmador local de TikTok.
+
+Las tramas se fabrican con el mismo protobuf que usa la librería
+(TikTokLive.proto), así que ninguna prueba necesita tocar la red de TikTok ni
+guardar capturas reales, que llevarían firma dentro.
+"""
+
+import base64
+import gzip
+
+from TikTokLive.proto import (
+    ProtoMessageFetchResult,
+    ProtoMessageFetchResultBaseProtoMessage,
+    PushHeader,
+    WebcastPushFrame,
+)
+
+
+def respuesta_con_mensajes(*metodos, cursor="1789072724354_0_1_1_0_0", need_ack=True):
+    """El ProtoMessageFetchResult que va dentro de una trama 'msg'."""
+    return ProtoMessageFetchResult(
+        messages=[
+            ProtoMessageFetchResultBaseProtoMessage(
+                method=metodo,
+                payload=b"",
+                msg_id=i + 1,
+                msg_type=1,
+                offset=0,
+                is_history=False,
+            )
+            for i, metodo in enumerate(metodos)
+        ],
+        cursor=cursor,
+        need_ack=need_ack,
+        internal_ext="ext",
+    )
+
+
+def trama(payload, *, payload_type="msg", compress_type="none", log_id=1, seq_id=1):
+    """Una trama binaria como las que el navegador recibe del webcast.
+
+    compress_type acepta 'none' y 'gzip' porque en un directo real llegan las
+    dos; None deja la trama sin la cabecera, que también pasa.
+    """
+    cabeceras = [PushHeader(key="im_cursor", value="c"), PushHeader(key="server_time", value="0")]
+    if compress_type is not None:
+        cabeceras.insert(0, PushHeader(key="compress_type", value=compress_type))
+    if compress_type == "gzip":
+        payload = gzip.compress(payload)
+    return bytes(
+        WebcastPushFrame(
+            payload_type=payload_type,
+            payload_encoding="pb",
+            payload=payload,
+            headers=cabeceras,
+            log_id=log_id,
+            seq_id=seq_id,
+        )
+    )
+
+
+def trama_msg(*metodos, compress_type="none", **kwargs):
+    """Trama 'msg' con los eventos indicados (sin ninguno, si no se pasa nada)."""
+    return trama(
+        bytes(respuesta_con_mensajes(*metodos, **kwargs)), compress_type=compress_type
+    )
+
+
+def trama_hb():
+    """El latido que manda el servidor: transporte, sin eventos dentro."""
+    return trama(b"", payload_type="hb")
+
+
+def en_base64(datos):
+    return base64.b64encode(datos).decode("ascii")

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -13,6 +13,7 @@ PLATAFORMAS = [
     "La sala de juegos",
     "Kick",
     "Discord",
+    "TikTok",  # 7: mismo chat que TikTok, pero leido del navegador (firmador local)
 ]
 
 
@@ -61,6 +62,7 @@ class MyFrame(wx.Frame):
                 _("La sala de juegos"),
                 _("Kick"),
                 _("Discord"),
+                _("TikTok (navegador, experimental)"),
             ],
         )
         self.plataforma.SetSelection(0)

--- a/utils/fajustes.py
+++ b/utils/fajustes.py
@@ -58,6 +58,11 @@ configuraciones = {
     "leer_historial": True,
     "update_channel": "stable",
     "create_backup_before_update": True,
+    # Firmador local del chat de TikTok: en vez de pedirle la firma a un
+    # servicio externo, VeTube lee las tramas que el navegador del usuario ya
+    # está recibiendo en el directo abierto. Apagado de fábrica porque hace
+    # falta la extensión puesta en el navegador para que llegue algo.
+    "tiktok_firmador_local": False,
 }
 actualizar_configuracion = False
 


### PR DESCRIPTION
## Qué resuelve

El chat de TikTok exige que la petición al websocket vaya **firmada**, y la librería `TikTokLive` delega esa firma en el servicio remoto **EulerStream**, que se cae seguido y comparte cupo. Cuando está caído, VeTube no puede leer ningún directo de TikTok.

Esta rama agrega una alternativa que **no depende de ningún firmador remoto**: el navegador del usuario, al abrir el directo, ya hace la petición firmada por su cuenta. Una extensión copia las tramas del chat que el navegador ya recibe y se las pasa a VeTube por un puerto local. No se recalcula ninguna firma y la sesión del usuario no sale de su navegador.

## Cómo funciona

- **`interceptor_extension/`** — extensión (Manifest V3) que lee las tramas del websocket del webcast con la **API de depuración de Chrome** (`chrome.debugger`, `Network.webSocketFrameReceived`). Se eligió esa vía porque la CSP de TikTok bloquea los content scripts del mundo MAIN (la documentación de Chrome lo confirma: al inyectar en el mundo MAIN se aplica la CSP de la página). La extensión reenvía las tramas, en base64, a `127.0.0.1:8790`. Nunca manda la cookie de sesión.
- **`servicios/tiktok_interceptor.py`** — servidor local (solo `127.0.0.1`) que recibe las tramas. Contrato: `GET /salud`, `POST /sesion`, `POST /tramas`.
- **`servicios/tiktok_espejo.py`** — reemplaza el cliente de websocket de `TikTokLive` por un "espejo" que lee de ese servidor en vez de conectarse a TikTok. No firma ni abre ninguna conexión saliente.

## Cómo se usa

En **"Capturar el chat de:"** hay una entrada nueva: **"TikTok (navegador, experimental)"**, que usa este camino. La entrada **"TikTok"** de siempre sigue usando EulerStream. Y si la conexión por EulerStream falla, se ofrece pasar al navegador con un aviso.

## Notas

- Es **experimental** y requiere tener la extensión cargada y el directo abierto en el navegador.
- Incluye tests (`tests/test_tiktok_interceptor.py`, `tests/test_tiktok_espejo.py`) que ejercitan el parseo de tramas con protobuf sintético, sin tocar la red real de TikTok.
- Verificado de punta a punta contra directos reales: la extensión captura las tramas, VeTube las decodifica con el propio protobuf de la librería y dispara los eventos de chat normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
